### PR TITLE
Add chat transcript plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# MHTP Plugins
+
+This repository contains a collection of custom WordPress plugins used by the Mental Health Triage Platform (MHTP). Each plugin lives in its own directory and includes its own README with installation and usage details.
+
+## Plugins
+
+- **mhtp-chat-access-control-v2** – Controls user access to the chat page based on login status and available sessions.
+- **mhtp-chat-woocommerce-v1.3.3-final** – Provides a chat interface for experts with WooCommerce integration and session tracking.
+- **mhtp-current-sessions-v9-seconds** – Tracks current chat sessions in real time.
+- **mhtp-expert-list-v2** – Displays a list of experts that users can choose from when starting a chat.
+- **mhtp-session-history-reset** – Allows administrators to reset session history for troubleshooting.
+- **mhtp-test-sessions** – Manages free or trial sessions for users with WooCommerce integration.
+- **mhtp-anonymous-checkout** – Enables checkout of products without requiring a WordPress account.
+
+Additional archived versions and zipped distributions of the plugins can be found in the `Archive` directory.
+
+## Development
+
+This repository only includes the plugin source code. Each plugin can be zipped and installed on a WordPress site via the admin plugin uploader. See each plugin's README for details about configuration and usage.

--- a/mhtp-chat-transcript/README.md
+++ b/mhtp-chat-transcript/README.md
@@ -1,0 +1,24 @@
+# MHTP Chat Transcript
+
+Registers a REST endpoint to save chat transcripts when the user has given consent.
+
+## Endpoint
+
+`POST /wp-json/chatlog/v1/save`
+
+The request must be authenticated using Basic Auth or a logged-in session cookie. If the `consent` field in the JSON payload is `true`, the transcript data is stored in the `wp_mhtp_chat_logs` table and the response is `{"stored": true}`. When `consent` is `false`, the endpoint returns `204 No Content` and nothing is saved.
+
+### Sample cURL
+
+```bash
+curl -X POST -u username:password \
+  -H "Content-Type: application/json" \
+  -d '{
+    "consent": true,
+    "convo_id": "abc123",
+    "summary": "Chat summary",
+    "transcript": "Full transcript text...",
+    "sentiment": "positive"
+  }' \
+  https://example.com/wp-json/chatlog/v1/save
+```

--- a/mhtp-chat-transcript/mhtp-chat-transcript.php
+++ b/mhtp-chat-transcript/mhtp-chat-transcript.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Plugin Name: MHTP Chat Transcript
+ * Description: Stores chat transcripts via REST API.
+ * Version: 1.0.0
+ * Author: Araujo Innovations
+ * Text Domain: mhtp-chat-transcript
+ */
+
+// Abort if accessed directly.
+if ( ! defined( 'WPINC' ) ) {
+    die;
+}
+
+/**
+ * Create database table on activation.
+ */
+function mhtp_chat_transcript_activate() {
+    global $wpdb;
+    $table_name = $wpdb->prefix . 'mhtp_chat_logs';
+    $charset_collate = $wpdb->get_charset_collate();
+
+    $sql = "CREATE TABLE $table_name (
+        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+        wp_user_id bigint(20) unsigned NOT NULL,
+        convo_id varchar(255) NOT NULL,
+        summary text NOT NULL,
+        transcript longtext NOT NULL,
+        sentiment varchar(20) NOT NULL,
+        created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY  (id)
+    ) $charset_collate;";
+
+    require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+    dbDelta( $sql );
+}
+register_activation_hook( __FILE__, 'mhtp_chat_transcript_activate' );
+
+/**
+ * Permission callback for the REST route.
+ */
+function mhtp_chatlog_permission() {
+    if ( is_user_logged_in() ) {
+        return true;
+    }
+
+    if ( isset( $_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'] ) ) {
+        $user = wp_authenticate( $_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'] );
+        if ( ! is_wp_error( $user ) ) {
+            wp_set_current_user( $user->ID );
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Handle POST /chatlog/v1/save
+ */
+function mhtp_chatlog_save( WP_REST_Request $request ) {
+    $params = $request->get_json_params();
+    if ( empty( $params['consent'] ) ) {
+        return new WP_REST_Response( null, 204 );
+    }
+
+    global $wpdb;
+    $table = $wpdb->prefix . 'mhtp_chat_logs';
+
+    $wpdb->insert(
+        $table,
+        array(
+            'wp_user_id' => get_current_user_id(),
+            'convo_id'   => isset( $params['convo_id'] ) ? sanitize_text_field( $params['convo_id'] ) : '',
+            'summary'    => isset( $params['summary'] ) ? wp_kses_post( $params['summary'] ) : '',
+            'transcript' => isset( $params['transcript'] ) ? wp_kses_post( $params['transcript'] ) : '',
+            'sentiment'  => isset( $params['sentiment'] ) ? sanitize_text_field( $params['sentiment'] ) : '',
+        ),
+        array( '%d', '%s', '%s', '%s', '%s' )
+    );
+
+    return array( 'stored' => true );
+}
+
+/**
+ * Register REST route.
+ */
+function mhtp_chat_transcript_rest() {
+    register_rest_route(
+        'chatlog/v1',
+        '/save',
+        array(
+            'methods'             => 'POST',
+            'callback'            => 'mhtp_chatlog_save',
+            'permission_callback' => 'mhtp_chatlog_permission',
+        )
+    );
+}
+add_action( 'rest_api_init', 'mhtp_chat_transcript_rest' );


### PR DESCRIPTION
## Summary
- add new `mhtp-chat-transcript` plugin that saves chat logs via REST
- document the endpoint with a cURL example

## Testing
- `echo "No tests" && true`
