### PR TITLE
Add Botpress proxy REST endpoint

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/README.md
+++ b/mhtp-chat-woocommerce-v1.3.3-final/README.md
@@ -44,6 +44,9 @@ This plugin now properly handles session decrementation when users start a chat:
 - Fixed expert list rendering by restoring original data passing mechanism
 - Restored original plugin structure for better compatibility
 
+### 1.3.4
+- Added REST endpoint `mhtp-chat/v1/message` to proxy messages to Botpress.
+
 ### 1.2.0
 - Added PDF download functionality
 - Enhanced chat interface styling


### PR DESCRIPTION
## Summary
- define `MHTP_BOTPRESS_API_URL` constant
- register REST route `mhtp-chat/v1/message`
- implement proxy handler forwarding requests to Botpress
- document new endpoint in plugin README

## Testing
- `git status --short`
- `git log -1 --stat`