### PR TITLE
Add debug log to register_rest_routes()

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
@@ -338,6 +338,7 @@ class MHTP_Chat_Interface {
      * Register REST routes.
      */
     public function register_rest_routes() {
+        error_log('MHTP Chat Interface → register_rest_routes() invoked');
         register_rest_route(
             'mhtp-chat/v1',
             '/message',


### PR DESCRIPTION
## Summary
- add a call to `error_log()` before registering REST routes

## Testing
- `grep -n "error_log" mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php`