### PR TITLE
Update Botpress API URL to published Webchat embed link

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/README.md
+++ b/mhtp-chat-woocommerce-v1.3.3-final/README.md
@@ -15,6 +15,8 @@ MHTP Chat Interface is a WordPress plugin that provides a chat interface for exp
 - MHTP Test Sessions plugin (optional, for test session management)
 
 ## Installation
+> ⚙️ **Botpress URL**: now reads from  
+> `MHTP_BOTPRESS_API_URL` constant pointing to your published webchat config URL.
 1. Upload the plugin files to the `/wp-content/plugins/mhtp-chat-woocommerce` directory, or install the plugin through the WordPress plugins screen
 2. Activate the plugin through the 'Plugins' screen in WordPress
 3. Use the shortcode `[mhtp_chat_interface]` or `[mhtp_chat]` to display the chat interface on any page or post

--- a/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
@@ -23,7 +23,10 @@ define('MHTP_CHAT_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('MHTP_CHAT_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('MHTP_CHAT_PLUGIN_FILE', __FILE__);
 // Endpoint for forwarding messages to Botpress
-define('MHTP_BOTPRESS_API_URL', 'https://botpress.example.com/api/message');
+define(
+    'MHTP_BOTPRESS_API_URL',
+    'https://cdn.botpress.cloud/webchat/v2.4/shareable.html?configUrl=https://files.bpcontent.cloud/2025/05/24/12/20250524123453-GNTZTZNC.json'
+);
 
 /**
  * Main plugin class
@@ -338,6 +341,7 @@ class MHTP_Chat_Interface {
      * Register REST routes.
      */
     public function register_rest_routes() {
+        error_log('MHTP Chat Interface → register_rest_routes() invoked');
         register_rest_route(
             'mhtp-chat/v1',
             '/message',


### PR DESCRIPTION
## Summary
- update `MHTP_BOTPRESS_API_URL` constant to point to published Botpress webchat
- note new constant location under Installation in plugin README

## Testing
- `grep -n "MHTP_BOTPRESS_API_URL" mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php`
- `grep -n "Botpress URL" mhtp-chat-woocommerce-v1.3.3-final/README.md`
