### PR TITLE
Add debug log to register_rest_routes()

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/README.md
+++ b/mhtp-chat-woocommerce-v1.3.3-final/README.md
@@ -19,6 +19,9 @@ MHTP Chat Interface is a WordPress plugin that provides a chat interface for exp
 2. Activate the plugin through the 'Plugins' screen in WordPress
 3. Use the shortcode `[mhtp_chat_interface]` or `[mhtp_chat]` to display the chat interface on any page or post
 
+> \u2699\ufe0f **Botpress URL**: now reads from  
+> `MHTP_BOTPRESS_API_URL` constant pointing to your published webchat config URL.
+
 ## Usage
 The plugin provides two shortcodes:
 - `[mhtp_chat_interface]` - The main shortcode
@@ -45,7 +48,10 @@ This plugin now properly handles session decrementation when users start a chat:
 - Restored original plugin structure for better compatibility
 
 ### 1.3.4
-- Added REST endpoint `mhtp-chat/v1/message` to proxy messages to Botpress.
+- Botpress URL now read from `MHTP_BOTPRESS_API_URL` constant pointing to your published webchat config.
+- Expose REST endpoint URL and nonce via `mhtpChatConfig` in the PHP registration routine.
+- Secure route with WP nonce permission callback.
+- sendMessage() now POSTs to the localized REST endpoint with fetch() and handles JSON reply.
 
 ### 1.2.0
 - Added PDF download functionality
@@ -60,3 +66,17 @@ This plugin now properly handles session decrementation when users start a chat:
 
 ## Credits
 Developed by Araujo Innovations
+
+## Usage example
+```js
+fetch(mhtpChatConfig.rest_url, {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'X-WP-Nonce': mhtpChatConfig.nonce
+  },
+  body: JSON.stringify({ message: 'Hola desde staging' })
+})
+  .then(r => r.json())
+  .then(d => console.log('Bot response:', d.text));
+```

--- a/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
@@ -23,7 +23,10 @@ define('MHTP_CHAT_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('MHTP_CHAT_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('MHTP_CHAT_PLUGIN_FILE', __FILE__);
 // Endpoint for forwarding messages to Botpress
-define('MHTP_BOTPRESS_API_URL', 'https://botpress.example.com/api/message');
+define(
+    'MHTP_BOTPRESS_API_URL',
+    'https://cdn.botpress.cloud/webchat/v2.4/shareable.html?configUrl=https://files.bpcontent.cloud/2025/05/24/12/20250524123453-GNTZTZNC.json'
+);
 
 /**
  * Main plugin class
@@ -338,6 +341,7 @@ class MHTP_Chat_Interface {
      * Register REST routes.
      */
     public function register_rest_routes() {
+        error_log('MHTP Chat Interface → register_rest_routes() invoked');
         register_rest_route(
             'mhtp-chat/v1',
             '/message',


### PR DESCRIPTION
## Summary
- log when `register_rest_routes()` runs
- update Botpress URL constant to published webchat embed link
- document the constant under Installation
- expand changelog for v1.3.4
- add usage example snippet for sending messages via fetch

## Testing
- `grep -n "error_log('MHTP Chat Interface" mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php`
