### PR TITLE
Release v1.3.4: add nonce header to REST fetch

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/README.md
+++ b/mhtp-chat-woocommerce-v1.3.3-final/README.md
@@ -47,23 +47,8 @@ This plugin now properly handles session decrementation when users start a chat:
 
 ## Changelog
 
-### 1.x.y
-- Version bumped to **1.x.y**.
-- Introduced the constant `MHTP_BOTPRESS_API_URL` pointing to your published webchat config URL.
-- Front-end script now posts messages with:
-```js
-fetch(mhtpChatConfig.rest_url, {
-  method: 'POST',
-  headers: {
-    'Content-Type': 'application/json',
-    'X-WP-Nonce': mhtpChatConfig.nonce
-  },
-  credentials: 'same-origin',
-  body: JSON.stringify({ message })
-})
-```
-- Added diagnostic logging in `rest_proxy_message()`; check your PHP error log with:
-`grep "→ rest_proxy_message" error_log`
+### 1.3.4
+- Added nonce header to REST fetch.
 
 ### 1.3.0
 - Added unified session management for both test and paid sessions
@@ -73,7 +58,7 @@ fetch(mhtpChatConfig.rest_url, {
 - Fixed expert list rendering by restoring original data passing mechanism
 - Restored original plugin structure for better compatibility
 
-### 1.3.4
+### 1.3.3
 - Botpress URL now read from `MHTP_BOTPRESS_API_URL` constant pointing to your published webchat config.
 - Expose REST endpoint URL and nonce via `mhtpChatConfig` in the PHP registration routine.
 - Secure route with WP nonce permission callback.

--- a/mhtp-chat-woocommerce-v1.3.3-final/js/chat-interface.js
+++ b/mhtp-chat-woocommerce-v1.3.3-final/js/chat-interface.js
@@ -191,8 +191,8 @@ jQuery(document).ready(function($) {
             fetch(mhtpChatConfig.rest_url, {
                 method: 'POST',
                 headers: {
-                    'Content-Type': 'application/json'
-                    // 'X-WP-Nonce': mhtpChatConfig.nonce
+                    'Content-Type': 'application/json',
+                    'X-WP-Nonce': mhtpChatConfig.nonce
                 },
                 credentials: 'same-origin',
                 body: JSON.stringify({ message })

--- a/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
@@ -3,7 +3,7 @@
  * Plugin Name: MHTP Chat Interface
  * Plugin URI: https://mhtp.com
  * Description: Chat interface for Mental Health Triage Platform
- * Version: 1.3.3
+ * Version: 1.3.4
  * Author: MHTP Team
  * Author URI: https://mhtp.com
  * Text Domain: mhtp-chat-interface
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('MHTP_CHAT_VERSION', '1.3.3');
+define('MHTP_CHAT_VERSION', '1.3.4');
 define('MHTP_CHAT_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('MHTP_CHAT_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('MHTP_CHAT_PLUGIN_FILE', __FILE__);


### PR DESCRIPTION
## Summary
- bump mhtp-chat-woocommerce plugin version to **1.3.4**
- include `X-WP-Nonce` header in JavaScript fetch call
- document the change in the plugin changelog

## Testing
- `pre-commit` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*