### PR TITLE
Switch chat plugin to Botpress Cloud API

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/README.md
+++ b/mhtp-chat-woocommerce-v1.3.3-final/README.md
@@ -15,16 +15,13 @@ MHTP Chat Interface is a WordPress plugin that provides a chat interface for exp
 - MHTP Test Sessions plugin (optional, for test session management)
 
 ## Installation
-> ⚙️ **Botpress URL**: now reads from  
-> `MHTP_BOTPRESS_API_URL` constant pointing to your published webchat config URL.
+> Botpress integration now uses the official API. Configure the
+> `MHTP_BOTPRESS_API_URL` and `MHTP_BOTPRESS_API_KEY` constants with your
+> Botpress Cloud endpoint and API key.
 1. Upload the plugin files to the `/wp-content/plugins/mhtp-chat-woocommerce` directory, or install the plugin through the WordPress plugins screen
 2. Activate the plugin through the 'Plugins' screen in WordPress
 3. Use the shortcode `[mhtp_chat_interface]` or `[mhtp_chat]` to display the chat interface on any page or post
-4. ⚙️ **Botpress URL**: now reads from
-   `MHTP_BOTPRESS_API_URL` constant pointing to your published webchat config URL.
-
-> \u2699\ufe0f **Botpress URL**: now reads from  
-> `MHTP_BOTPRESS_API_URL` constant pointing to your published webchat config URL.
+4. Ensure the constants `MHTP_BOTPRESS_API_URL` and `MHTP_BOTPRESS_API_KEY` are set in `mhtp-chat-interface.php`.
 
 ## Usage
 The plugin provides two shortcodes:
@@ -49,6 +46,11 @@ This plugin now properly handles session decrementation when users start a chat:
 
 ## Changelog
 
+### 1.4.0
+- Switched to the Botpress Cloud programmatic API with support for API keys.
+- Added new constants `MHTP_BOTPRESS_API_URL` and `MHTP_BOTPRESS_API_KEY`.
+- REST proxy now logs any unexpected HTTP status codes.
+
 ### 1.3.5
 - Fixed 403 errors when sending messages by replacing the REST route permission
   callback with an anonymous function. A debug log entry now confirms the
@@ -71,7 +73,7 @@ This plugin now properly handles session decrementation when users start a chat:
 - Restored original plugin structure for better compatibility
 
 ### 1.3.3
-- Botpress URL now read from `MHTP_BOTPRESS_API_URL` constant pointing to your published webchat config.
+- Botpress URL now read from `MHTP_BOTPRESS_API_URL` constant pointing to your Botpress Cloud API.
 - Expose REST endpoint URL and nonce via `mhtpChatConfig` in the PHP registration routine.
 - Secure route with WP nonce permission callback.
 - sendMessage() now POSTs to the localized REST endpoint with fetch() and handles JSON reply.


### PR DESCRIPTION
## Summary
- update Botpress API constants and bump version
- send REST proxy requests to the Botpress Cloud API with API key
- log non‑200 Botpress responses
- document new configuration in README

## Testing
- `php -l mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php` *(fails: `php` not found)*