### PR TITLE
Switch chat plugin to Botpress Cloud API

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/README.md
+++ b/mhtp-chat-woocommerce-v1.3.3-final/README.md
@@ -1,4 +1,4 @@
-# MHTP Chat Interface - Version 1.3.0
+# MHTP Chat Interface - Version 1.4.0
 
 ## Description
 MHTP Chat Interface is a WordPress plugin that provides a chat interface for experts with WooCommerce integration. This plugin allows users to chat with experts who are set up as WooCommerce products.
@@ -15,16 +15,14 @@ MHTP Chat Interface is a WordPress plugin that provides a chat interface for exp
 - MHTP Test Sessions plugin (optional, for test session management)
 
 ## Installation
-> ⚙️ **Botpress URL**: now reads from  
-> `MHTP_BOTPRESS_API_URL` constant pointing to your published webchat config URL.
+> Botpress integration now uses the official API. Configure the
+> `MHTP_BOTPRESS_API_URL` constant with your Botpress Cloud endpoint
+> (`https://api.botpress.cloud/v1/bots/<BOT_ID>/converse/`) and set
+> `MHTP_BOTPRESS_API_KEY` to your Botpress personal access token.
 1. Upload the plugin files to the `/wp-content/plugins/mhtp-chat-woocommerce` directory, or install the plugin through the WordPress plugins screen
 2. Activate the plugin through the 'Plugins' screen in WordPress
 3. Use the shortcode `[mhtp_chat_interface]` or `[mhtp_chat]` to display the chat interface on any page or post
-4. ⚙️ **Botpress URL**: now reads from
-   `MHTP_BOTPRESS_API_URL` constant pointing to your published webchat config URL.
-
-> \u2699\ufe0f **Botpress URL**: now reads from  
-> `MHTP_BOTPRESS_API_URL` constant pointing to your published webchat config URL.
+4. Ensure the constants `MHTP_BOTPRESS_API_URL` and `MHTP_BOTPRESS_API_KEY` are set in `mhtp-chat-interface.php`.
 
 ## Usage
 The plugin provides two shortcodes:
@@ -49,6 +47,14 @@ This plugin now properly handles session decrementation when users start a chat:
 
 ## Changelog
 
+### 1.4.0
+- Switched to the Botpress Cloud programmatic API with support for API keys.
+- Added new constants `MHTP_BOTPRESS_API_URL` and `MHTP_BOTPRESS_API_KEY`.
+- REST proxy now logs any unexpected HTTP status codes and prints the full
+  Botpress response for debugging.
+- Requests are sent to `/converse/<WP user ID>` so each WordPress user has a
+  unique conversation context.
+
 ### 1.3.5
 - Fixed 403 errors when sending messages by replacing the REST route permission
   callback with an anonymous function. A debug log entry now confirms the
@@ -71,7 +77,7 @@ This plugin now properly handles session decrementation when users start a chat:
 - Restored original plugin structure for better compatibility
 
 ### 1.3.3
-- Botpress URL now read from `MHTP_BOTPRESS_API_URL` constant pointing to your published webchat config.
+- Botpress URL now read from `MHTP_BOTPRESS_API_URL` constant pointing to your Botpress Cloud API.
 - Expose REST endpoint URL and nonce via `mhtpChatConfig` in the PHP registration routine.
 - Secure route with WP nonce permission callback.
 - sendMessage() now POSTs to the localized REST endpoint with fetch() and handles JSON reply.

--- a/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
@@ -3,7 +3,7 @@
  * Plugin Name: MHTP Chat Interface
  * Plugin URI: https://mhtp.com
  * Description: Chat interface for Mental Health Triage Platform
- * Version: 1.3.4
+ * Version: 1.4.0
  * Author: MHTP Team
  * Author URI: https://mhtp.com
  * Text Domain: mhtp-chat-interface
@@ -18,15 +18,18 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('MHTP_CHAT_VERSION', '1.3.4');
+define('MHTP_CHAT_VERSION', '1.4.0');
 define('MHTP_CHAT_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('MHTP_CHAT_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('MHTP_CHAT_PLUGIN_FILE', __FILE__);
-// Endpoint for forwarding messages to Botpress
+// Botpress identifiers
+define('MHTP_BOTPRESS_BOT_ID', 'e7a32e4e-fb02-4934-b58f-94c0679c30f9');
 define(
     'MHTP_BOTPRESS_API_URL',
-    'https://cdn.botpress.cloud/webchat/v2.4/shareable.html?configUrl=https://files.bpcontent.cloud/2025/05/24/12/20250524123453-GNTZTZNC.json'
+    'https://api.botpress.cloud/v1/bots/' . MHTP_BOTPRESS_BOT_ID . '/converse/'
 );
+// API key for authenticating with Botpress Cloud
+define('MHTP_BOTPRESS_API_KEY', 'bp_pat_1GA5jZRedOXowriuF3bg4C07q9jgzaPHni8K');
 
 /**
  * Main plugin class
@@ -386,11 +389,19 @@ class MHTP_Chat_Interface {
         // Forward the message to Botpress and ensure we always
         // return a valid WP_REST_Response for the frontend.
 
+        $botpress_url = MHTP_BOTPRESS_API_URL . get_current_user_id();
+
         $response = wp_remote_post(
-            MHTP_BOTPRESS_API_URL,
+            $botpress_url,
             array(
-                'headers' => array('Content-Type' => 'application/json'),
-                'body'    => wp_json_encode(array('message' => $message)),
+                'headers' => array(
+                    'Content-Type'  => 'application/json',
+                    'Authorization' => 'Bearer ' . MHTP_BOTPRESS_API_KEY,
+                ),
+                'body'    => wp_json_encode(array(
+                    'type' => 'text',
+                    'text' => $message,
+                )),
                 'timeout' => 15,
             )
         );
@@ -403,10 +414,17 @@ class MHTP_Chat_Interface {
         $code = wp_remote_retrieve_response_code($response);
         $body = wp_remote_retrieve_body($response);
 
+        if ($code < 200 || $code >= 300) {
+            error_log('Unexpected Botpress status ' . $code . ': ' . $body);
+            return new WP_REST_Response(array('error' => 'Unexpected response from Botpress'), 502);
+        }
+
         if (empty($body)) {
             error_log('Botpress returned empty body');
             return new WP_REST_Response(array('error' => 'Empty response from Botpress'), 502);
         }
+
+        error_log('Botpress response: ' . $body);
 
         $decoded = json_decode($body, true);
 


### PR DESCRIPTION
## Summary
- update Botpress API constants and bump version
- send REST proxy requests to the Botpress Cloud API with API key
- log non‑200 Botpress responses and full body
- document new configuration in README

## Testing
- `php -l mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php` *(fails: `php` not found)*