### PR TITLE
Switch to Botpress Cloud Chat API

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/README.md
+++ b/mhtp-chat-woocommerce-v1.3.3-final/README.md
@@ -1,4 +1,4 @@
-# MHTP Chat Interface - Version 1.4.0
+# MHTP Chat Interface - Version 2.0.1
 
 ## Description
 MHTP Chat Interface is a WordPress plugin that provides a chat interface for experts with WooCommerce integration. This plugin allows users to chat with experts who are set up as WooCommerce products.
@@ -14,16 +14,18 @@ MHTP Chat Interface is a WordPress plugin that provides a chat interface for exp
 - WooCommerce 4.0 or higher
 - MHTP Test Sessions plugin (optional, for test session management)
 
-## Installation
-> Botpress integration now uses the official API. Configure the
-> `MHTP_BOTPRESS_API_URL` constant with your Botpress Cloud endpoint
-> (`https://api.botpress.cloud/v1/bots/<BOT_ID>/converse/`) and set
-> `MHTP_BOTPRESS_API_KEY` to your Botpress personal access token.
+## Migrating from Legacy API
+Previous versions of this plugin used the `/converse` endpoint from Botpress v12. That endpoint no longer works on Botpress Cloud and will return 404 errors. Version 2.0.0 now uses the Chat API. Ensure the Chat Integration is enabled on your bot and update your API key before upgrading.
 
-1. Upload the plugin files to the `/wp-content/plugins/mhtp-chat-woocommerce` directory, or install the plugin through the WordPress plugins screen
-2. Activate the plugin through the 'Plugins' screen in WordPress
-3. Use the shortcode `[mhtp_chat_interface]` or `[mhtp_chat]` to display the chat interface on any page or post
-4. Ensure the constants `MHTP_BOTPRESS_API_URL` and `MHTP_BOTPRESS_API_KEY` are set in `mhtp-chat-interface.php`.
+## Installation
+1. In Botpress Cloud, enable the **Chat Integration** for your bot and note the API key.
+2. Define the constant `MHTP_BOTPRESS_API_KEY` in your `wp-config.php` file with the key from step 1.
+3. Upload the plugin files to `/wp-content/plugins/mhtp-chat-woocommerce` or install through the WordPress plugins screen.
+4. Activate the plugin through the 'Plugins' menu.
+5. Use the shortcode `[mhtp_chat_interface]` (or `[mhtp_chat]`) on any page.
+
+The plugin communicates with Botpress using the Chat API at `https://chat.botpress.cloud/v1`. A user and conversation are created automatically when a chat session starts.
+
 
 ## Usage
 The plugin provides two shortcodes:
@@ -32,6 +34,13 @@ The plugin provides two shortcodes:
 
 You can specify an expert ID directly:
 - `[mhtp_chat_interface expert_id="123"]`
+
+### AJAX Handlers
+The plugin registers the actions `wp_ajax_mhtp_start_chat_session` and
+`wp_ajax_nopriv_mhtp_start_chat_session`. These handlers create the Botpress
+conversation when the chat UI loads. If they are missing, every AJAX request
+will return an empty response and the front end will display "Failed to prepare
+chat user".
 
 The front-end script sends messages via `fetch` to the localized REST
 endpoint. Ensure `mhtpChatConfig.rest_url` and `mhtpChatConfig.nonce` are
@@ -48,13 +57,22 @@ This plugin now properly handles session decrementation when users start a chat:
 
 ## Changelog
 
+
+### 2.0.1
+- Register AJAX handlers for `mhtp_start_chat_session` for logged in and guest
+  users. The lack of these hooks previously caused chat initialization failures.
+
+### 2.0.0
+- Migrated to Botpress **Chat API** at `https://chat.botpress.cloud/v1`.
+- Users and conversations are created automatically when a session begins.
+- New optional webhook endpoint `/mhtp-chat/v1/webhook` for asynchronous events.
+- API key is now read from `MHTP_BOTPRESS_API_KEY` defined in `wp-config.php`.
+
 ### 1.4.0
-- Switched to the Botpress Cloud programmatic API with support for API keys.
+- Switched to the Botpress Cloud programmatic API with support for API keys (legacy approach).
 - Added new constants `MHTP_BOTPRESS_API_URL` and `MHTP_BOTPRESS_API_KEY`.
-- REST proxy now logs any unexpected HTTP status codes and prints the full
-  Botpress response for debugging.
-- Requests are sent to `/converse/<WP user ID>` so each WordPress user has a
-  unique conversation context.
+- REST proxy now logs unexpected HTTP status codes with full Botpress response.
+- Requests were sent to `/converse/<WP user ID>` for conversation context.
 
 ### 1.3.5
 - Fixed 403 errors when sending messages by replacing the REST route permission
@@ -110,3 +128,6 @@ fetch(mhtpChatConfig.rest_url, {
   .then(r => r.json())
   .then(d => console.log('Bot response:', d.text));
 ```
+
+## Security & Rate Limits
+Keep your Botpress API key secret. Define `MHTP_BOTPRESS_API_KEY` in `wp-config.php` outside your web root. The Chat API enforces rate limits, so avoid unnecessary requests and handle errors gracefully.


### PR DESCRIPTION
## Summary
- migrate chat plugin to use Botpress Cloud Chat API
- create Botpress user and conversation when a chat session starts
- add optional webhook endpoint
- document new configuration steps and migration notes
- register AJAX handlers for start chat session for logged in and guest users

## Testing
- `php -l mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php` *(fails: `php` not installed)*
