### PR TITLE
Implement Botpress webhook secret

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/README.md
+++ b/mhtp-chat-woocommerce-v1.3.3-final/README.md
@@ -20,10 +20,11 @@ Previous versions of this plugin used the `/converse` endpoint from Botpress v12
 ## Installation
 1. In Botpress Cloud, enable the **Chat Integration** for your bot and note the API key.
 2. In that same Chat Integration screen set the **Webhook URL** to `https://YOURDOMAIN.com/wp-json/mhtp-chat/v1/webhook` (replace `YOURDOMAIN.com` with your domain).
-3. Define the constant `MHTP_BOTPRESS_API_KEY` in your `wp-config.php` file with the key from step&nbsp;1.
-4. Upload the plugin files to `/wp-content/plugins/mhtp-chat-woocommerce` or install through the WordPress plugins screen.
-5. Activate the plugin through the 'Plugins' menu.
-6. Use the shortcode `[mhtp_chat_interface]` (or `[mhtp_chat]`) on any page.
+3. *(Optional)* Define `MHTP_BOTPRESS_WEBHOOK_SECRET` in `wp-config.php` and configure Botpress to send `Authorization: Bearer <secret>` to this webhook.
+4. Define the constant `MHTP_BOTPRESS_API_KEY` in your `wp-config.php` file with the key from step&nbsp;1.
+5. Upload the plugin files to `/wp-content/plugins/mhtp-chat-woocommerce` or install through the WordPress plugins screen.
+6. Activate the plugin through the 'Plugins' menu.
+7. Use the shortcode `[mhtp_chat_interface]` (or `[mhtp_chat]`) on any page.
 
 The plugin communicates with Botpress using the Chat API at `https://chat.botpress.cloud/v1`. A user and conversation are created automatically when a chat session starts.
 
@@ -137,4 +138,4 @@ fetch(mhtpChatConfig.rest_url, {
 5. You can verify this value using the WordPress admin or `get_user_meta( get_current_user_id(), 'mhtp_last_bot_reply', true )`.
 
 ## Security & Rate Limits
-Keep your Botpress API key secret. Define `MHTP_BOTPRESS_API_KEY` in `wp-config.php` outside your web root. The Chat API enforces rate limits, so avoid unnecessary requests and handle errors gracefully.
+Keep your Botpress API key secret. Define `MHTP_BOTPRESS_API_KEY` in `wp-config.php` outside your web root. If you set `MHTP_BOTPRESS_WEBHOOK_SECRET`, Botpress must include `Authorization: Bearer <secret>` when calling the webhook. The Chat API enforces rate limits, so avoid unnecessary requests and handle errors gracefully.

--- a/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
@@ -34,6 +34,15 @@ if (!defined('MHTP_BOTPRESS_API_KEY')) {
     define('MHTP_BOTPRESS_API_KEY', '');
 }
 
+/*
+ * Optional secret to validate incoming webhook requests from Botpress.
+ * Set this constant in wp-config.php and configure the Botpress webhook
+ * to send an Authorization header of the form "Bearer <secret>".
+ */
+if (!defined('MHTP_BOTPRESS_WEBHOOK_SECRET')) {
+    define('MHTP_BOTPRESS_WEBHOOK_SECRET', '');
+}
+
 /**
  * Main plugin class
  */
@@ -466,6 +475,13 @@ class MHTP_Chat_Interface {
      * @return WP_REST_Response
      */
     public function rest_webhook_handler(WP_REST_Request $request) {
+        $auth_header = $request->get_header('Authorization');
+        $expected    = 'Bearer ' . MHTP_BOTPRESS_WEBHOOK_SECRET;
+        if ($auth_header !== $expected) {
+            error_log('Webhook authorization failed: ' . $auth_header);
+            return new WP_REST_Response(null, 401);
+        }
+
         $payload = $request->get_json_params();
         error_log('Botpress webhook received: ' . wp_json_encode($payload));
 


### PR DESCRIPTION
## Summary
- add `MHTP_BOTPRESS_WEBHOOK_SECRET` constant
- check the Botpress `Authorization` header in webhook handler
- explain webhook secret in plugin README

## Testing
- `php -l mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php` *(fails: php not installed)*