### PR TITLE
Add x-user-key header for Botpress API

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/README.md
+++ b/mhtp-chat-woocommerce-v1.3.3-final/README.md
@@ -1,4 +1,4 @@
-# MHTP Chat Interface - Version 2.0.1
+# MHTP Chat Interface - Version 2.0.2
 
 ## Description
 MHTP Chat Interface is a WordPress plugin that provides a chat interface for experts with WooCommerce integration. This plugin allows users to chat with experts who are set up as WooCommerce products.
@@ -23,9 +23,10 @@ Previous versions of this plugin used the `/converse` endpoint from Botpress v12
 3. Define the constant `MHTP_BOTPRESS_API_KEY` in your `wp-config.php` file with the key from step&nbsp;1.
 4. *(Optional)* Define `MHTP_BOTPRESS_CHAT_API` if your Chat API base differs or includes your bot ID (e.g. `https://bots.botpress.cloud/api/v1/bots/YOUR_BOT_ID`).
 
-5. Upload the plugin files to `/wp-content/plugins/mhtp-chat-woocommerce` or install through the WordPress plugins screen.
-6. Activate the plugin through the 'Plugins' menu.
-7. Use the shortcode `[mhtp_chat_interface]` (or `[mhtp_chat]`) on any page.
+5. All Botpress requests must include an `x-user-key` header. The plugin automatically sends this header using the logged in WordPress user ID (`wp-{user_id}`).
+6. Upload the plugin files to `/wp-content/plugins/mhtp-chat-woocommerce` or install through the WordPress plugins screen.
+7. Activate the plugin through the 'Plugins' menu.
+8. Use the shortcode `[mhtp_chat_interface]` (or `[mhtp_chat]`) on any page.
 
 The plugin communicates with Botpress using the base defined in `MHTP_BOTPRESS_CHAT_API`. This defaults to `https://chat.botpress.cloud/v1`, but some installations require the bot ID in the path. A user is created the first time they start chatting and the initial message is sent to the `/events` endpoint, which also creates a conversation automatically.
 
@@ -65,6 +66,8 @@ This plugin now properly handles session decrementation when users start a chat:
 ### 2.0.1
 - Register AJAX handlers for `mhtp_start_chat_session` for logged in and guest
   users. The lack of these hooks previously caused chat initialization failures.
+### 2.0.2
+- Added `x-user-key` header to all Botpress API requests using `wp-{user_id}` so requests comply with Botpress Cloud requirements.
 ### 2.0.0
 - Migrated to Botpress **Chat API** at `https://chat.botpress.cloud/v1`.
 - Users are created automatically and conversations start when the first event is sent.

--- a/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
@@ -3,7 +3,7 @@
  * Plugin Name: MHTP Chat Interface
  * Plugin URI: https://mhtp.com
  * Description: Chat interface for Mental Health Triage Platform
- * Version: 2.0.1
+ * Version: 2.0.2
  * Author: MHTP Team
  * Author URI: https://mhtp.com
  * Text Domain: mhtp-chat-interface
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('MHTP_CHAT_VERSION', '2.0.1');
+define('MHTP_CHAT_VERSION', '2.0.2');
 define('MHTP_CHAT_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('MHTP_CHAT_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('MHTP_CHAT_PLUGIN_FILE', __FILE__);
@@ -404,6 +404,7 @@ class MHTP_Chat_Interface {
             'headers' => array(
                 'Content-Type'  => 'application/json',
                 'Authorization' => 'Bearer ' . MHTP_BOTPRESS_API_KEY,
+                'x-user-key'   => $bp_user_id,
             ),
             'body'    => wp_json_encode(array('id' => $bp_user_id)),
             'timeout' => 15,
@@ -449,6 +450,7 @@ class MHTP_Chat_Interface {
             'headers' => array(
                 'Content-Type'  => 'application/json',
                 'Authorization' => 'Bearer ' . MHTP_BOTPRESS_API_KEY,
+                'x-user-key'   => $bp_user_id,
             ),
             'body'    => wp_json_encode($payload),
             'timeout' => 15,
@@ -609,6 +611,7 @@ class MHTP_Chat_Interface {
                 'headers' => array(
                     'Content-Type'  => 'application/json',
                     'Authorization' => 'Bearer ' . MHTP_BOTPRESS_API_KEY,
+                    'x-user-key'   => $bp_user_id,
                 ),
                 'body'    => wp_json_encode($payload),
                 'timeout' => 15,


### PR DESCRIPTION
## Summary
- ensure every Botpress request includes an `x-user-key` header
- bump plugin version to 2.0.2
- document the new header requirement in the README

## Testing
- `php -l mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php` *(fails: `php` not installed)*