### PR TITLE
Replace Botpress chat with Typebot shortcode

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/README.md
+++ b/mhtp-chat-woocommerce-v1.3.3-final/README.md
@@ -3,6 +3,8 @@
 ## Description
 MHTP Chat Interface is a WordPress plugin that provides a chat interface for experts with WooCommerce integration. This plugin allows users to chat with experts who are set up as WooCommerce products.
 
+**Note:** This version embeds a [Typebot](https://typebot.io) conversation instead of the previous Botpress-based chat UI while keeping the same page layout.
+
 ## New in Version 1.3.0
 - **Unified Session Management**: Now properly decrements sessions when users start a chat, working with both test sessions (from MHTP Test Sessions plugin) and paid sessions (from WooCommerce)
 - **Improved Session Tracking**: Added logging for session usage to help with reporting and analytics

--- a/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: MHTP Chat Interface
  * Plugin URI: https://mhtp.com
- * Description: Chat interface for Mental Health Triage Platform
+ * Description: Chat interface for Mental Health Triage Platform using Typebot
  * Version: 3.0.0
  * Author: MHTP Team
  * Author URI: https://mhtp.com
@@ -164,11 +164,9 @@ class MHTP_Chat_Interface {
                 '</div>';
         }
         
-        // Enqueue styles and scripts
+        // Enqueue styles only (Typebot handles its own scripts)
         wp_enqueue_style('mhtp-chat-interface');
         wp_enqueue_style('mhtp-button-fix');
-        wp_enqueue_script('mhtp-chat-interface');
-        wp_enqueue_script('mhtp-button-fix');
         
         // Start output buffering
         ob_start();

--- a/mhtp-chat-woocommerce-v1.3.3-final/templates/chat-interface.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/templates/chat-interface.php
@@ -85,65 +85,24 @@ if (!defined('ABSPATH')) {
         </div>
         
         <div class="mhtp-chat-main">
-            <div class="mhtp-chat-messages" id="mhtp-chat-messages">
-                <div class="mhtp-message mhtp-message-expert">
-                    <div class="mhtp-message-content">
-                        <p>Hola, soy <?php 
-                            // Extract just the name without any specialty or description
-                            $full_name = $expert['name'];
-                            
-                            // Special case for Lucía Apoyo
-                            if (strpos($full_name, 'Lucía Apoyo') !== false) {
-                                echo 'Lucía Apoyo';
-                            } else {
-                                // Handle different types of separators (dash, hyphen, en dash, em dash)
-                                $name_parts = preg_split('/\s*[-–—]\s*/', $full_name, 2);
-                                
-                                // If we have parts, use the first one, otherwise use the full name
-                                $clean_name = !empty($name_parts[0]) ? trim($name_parts[0]) : trim($full_name);
-                                
-                                // Remove any "Experto en", "Experta en", "Especialista en" prefixes
-                                $clean_name = preg_replace('/^(Experto|Experta|Especialista)\s+en\s+/i', '', $clean_name);
-                                
-                                echo esc_html($clean_name);
-                            }
-                        ?>. ¿En qué puedo ayudarte hoy?</p>
-                    </div>
-                    <div class="mhtp-message-time">Ahora</div>
-                </div>
-            </div>
-            
-            <div class="mhtp-chat-footer">
-                <div class="mhtp-chat-input-container">
-                    <textarea id="mhtp-chat-input" class="mhtp-chat-input" placeholder="Escribe tu mensaje aquí..."></textarea>
-                    <button id="mhtp-send-button" class="mhtp-send-button">Enviar</button>
-                </div>
-                
-                <div class="mhtp-chat-controls">
-                    <button id="mhtp-end-session" class="mhtp-end-session-button">Finalizar sesión</button>
-                    <div id="mhtp-session-timer" class="mhtp-session-timer">45:00</div>
-                </div>
-            </div>
+            <?php
+            $params = array(
+                'expertName' => !empty($expert['name']) ? $expert['name'] : '',
+            );
+            if (isset($_GET['topic'])) {
+                $params['topic'] = sanitize_text_field($_GET['topic']);
+            }
+            if (isset($_GET['is_client'])) {
+                $params['isClient'] = sanitize_text_field($_GET['is_client']);
+            }
+            $query = http_build_query(array_filter($params));
+            $shortcode = '[typebot typebot="especialista-5gzhab4" width="100%" height="600px"';
+            if ($query) {
+                $shortcode .= ' url_params="' . esc_attr($query) . '"';
+            }
+            $shortcode .= ']';
+            echo do_shortcode($shortcode);
+            ?>
         </div>
     </div>
 </div>
-
-<!-- Session End Confirmation Modal -->
-<div id="mhtp-end-session-modal" class="mhtp-modal">
-    <div class="mhtp-modal-content">
-        <div class="mhtp-modal-header">
-            <h3>Confirmar finalización</h3>
-        </div>
-        <div class="mhtp-modal-body">
-            <p>¿Estás seguro de que deseas finalizar la sesión de chat?</p>
-            <p>Una vez finalizada, no podrás continuar con esta conversación.</p>
-        </div>
-        <div class="mhtp-modal-footer">
-            <button id="mhtp-cancel-end-session" class="mhtp-button mhtp-button-secondary">Cancelar</button>
-            <button id="mhtp-confirm-end-session" class="mhtp-button mhtp-button-primary">Finalizar sesión</button>
-        </div>
-    </div>
-</div>
-
-<!-- Load jsPDF for PDF generation -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>

--- a/mhtp-typebot-chat/README.md
+++ b/mhtp-typebot-chat/README.md
@@ -1,0 +1,26 @@
+# MHTP Typebot Chat
+
+This plugin provides a minimal shortcode wrapper around the
+[Typebot](https://typebot.io) WordPress plugin. It replaces the previous
+Botpress-based chat interface.
+
+## Shortcode
+
+Use `[mhtp_chat]` to embed the Typebot conversation. Optional parameters can
+be passed and will be forwarded as URL parameters to Typebot:
+
+```
+[mhtp_chat expert_name="Lucia" topic="Anxiety" is_client="1"]
+```
+
+These values become available to your Typebot flow via the variables
+`expertName`, `topic` and `isClient`.
+
+The actual Typebot is embedded using:
+
+```
+[typebot typebot="especialista-5gzhab4" width="100%" height="600px"]
+```
+
+Any provided parameters are appended to the `url_params` attribute so they are
+available inside Typebot.

--- a/mhtp-typebot-chat/mhtp-typebot-chat.php
+++ b/mhtp-typebot-chat/mhtp-typebot-chat.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Plugin Name: MHTP Typebot Chat
+ * Description: Simple chat embedding using Typebot.
+ * Version: 0.1.0
+ * Author: MHTP Team
+ * Text Domain: mhtp-typebot-chat
+ */
+
+// Prevent direct access
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Shortcode to embed a Typebot conversation.
+ *
+ * Usage: [mhtp_chat expert_name="" topic="" is_client=""]
+ */
+function mhtp_typebot_chat_shortcode( $atts ) {
+    $atts = shortcode_atts( array(
+        'expert_name' => '',
+        'topic'       => '',
+        'is_client'   => '',
+    ), $atts, 'mhtp_chat' );
+
+    $params = array_filter( array(
+        'expertName' => $atts['expert_name'],
+        'topic'      => $atts['topic'],
+        'isClient'   => $atts['is_client'],
+    ) );
+
+    $query = http_build_query( $params );
+
+    $shortcode = '[typebot typebot="especialista-5gzhab4" width="100%" height="600px"';
+    if ( $query ) {
+        $shortcode .= ' url_params="' . esc_attr( $query ) . '"';
+    }
+    $shortcode .= ']';
+
+    return do_shortcode( $shortcode );
+}
+add_shortcode( 'mhtp_chat', 'mhtp_typebot_chat_shortcode' );


### PR DESCRIPTION
## Summary
- add new `mhtp-typebot-chat` plugin for embedding Typebot bots
- embed Typebot in the legacy `mhtp-chat-woocommerce` layout

## Testing
- `php -l mhtp-chat-woocommerce-v1.3.3-final/templates/chat-interface.php` *(fails: php not installed)*
- `php -l mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683c79284f408325983a2a483a027e35