### PR TITLE
Replace Botpress chat with Typebot iframe

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/README.md
+++ b/mhtp-chat-woocommerce-v1.3.3-final/README.md
@@ -1,5 +1,10 @@
 # MHTP Chat Interface - Version 3.0.0
 
+**Note:** This legacy plugin was originally built for Botpress. The
+newer `mhtp-typebot-chat` plugin replaces the Botpress integration with
+a simple Typebot embed. Only activate one of these plugins at a time to
+avoid shortcode conflicts.
+
 ## Description
 MHTP Chat Interface is a WordPress plugin that provides a chat interface for experts with WooCommerce integration. This plugin allows users to chat with experts who are set up as WooCommerce products.
 

--- a/mhtp-typebot-chat/README.md
+++ b/mhtp-typebot-chat/README.md
@@ -1,0 +1,23 @@
+# MHTP Typebot Chat
+
+This plugin embeds a [Typebot](https://typebot.io) conversation using a
+simple shortcode. It replaces the previous Botpress-based chat interface
+and uses a plain `<iframe>` so the official Typebot plugin is not
+required.
+
+## Shortcode
+
+Use `[mhtp_chat]` to embed the Typebot conversation. Optional parameters
+are forwarded as URL parameters to Typebot:
+
+```
+[mhtp_chat expert_name="Lucia" topic="Anxiety" is_client="1"]
+```
+
+These values become available to your Typebot flow via the variables
+`expertName`, `topic` and `isClient`.
+
+The shortcode renders an `<iframe>` pointing to your Typebot with any
+parameters appended to the query string. If the legacy plugin
+`mhtp-chat-woocommerce-v1.3.3-final` is active, deactivate it to avoid
+shortcode conflicts.

--- a/mhtp-typebot-chat/mhtp-typebot-chat.php
+++ b/mhtp-typebot-chat/mhtp-typebot-chat.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Plugin Name: MHTP Typebot Chat
+ * Description: Simple chat embedding using Typebot.
+ * Version: 0.1.0
+ * Author: MHTP Team
+ * Text Domain: mhtp-typebot-chat
+ */
+
+// Prevent direct access
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Shortcode to embed a Typebot conversation.
+ *
+ * Usage: [mhtp_chat expert_name="" topic="" is_client=""]
+ */
+function mhtp_typebot_chat_shortcode( $atts ) {
+    $atts = shortcode_atts(
+        array(
+            'expert_name' => '',
+            'topic'       => '',
+            'is_client'   => '',
+        ),
+        $atts,
+        'mhtp_chat'
+    );
+
+    $params = array_filter(
+        array(
+            'expertName' => $atts['expert_name'],
+            'topic'      => $atts['topic'],
+            'isClient'   => $atts['is_client'],
+        )
+    );
+
+    $query = $params ? '?' . http_build_query( $params ) : '';
+
+    $src = esc_url( 'https://embed.typebot.io/especialista-5gzhab4' . $query );
+
+    return sprintf(
+        '<iframe src="%s" width="100%%" height="600px" style="border:none;" allow="camera; microphone; clipboard-read; clipboard-write"></iframe>',
+        $src
+    );
+}
+add_shortcode( 'mhtp_chat', 'mhtp_typebot_chat_shortcode' );


### PR DESCRIPTION
## Summary
- switch to a simple Typebot iframe in `mhtp-typebot-chat`
- note in the legacy README that the old plugin relied on Botpress
- document the new shortcode usage

## Testing
- `php -l mhtp-typebot-chat/mhtp-typebot-chat.php` *(fails: php not installed)*
- `php -l mhtp-chat-woocommerce-v1.3.3-final/templates/chat-interface.php` *(fails: php not installed)*
- `php -l mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php` *(fails: php not installed)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_683c79284f408325983a2a483a027e35