### PR TITLE
Set typebot.io as default Typebot URL

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/README.md
+++ b/mhtp-chat-woocommerce-v1.3.3-final/README.md
@@ -4,6 +4,10 @@
 built-in support for embedding a [Typebot](https://typebot.io) conversation
 directly. The separate `mhtp-typebot-chat` plugin is no longer required.
 
+The embed uses `https://typebot.io/` by default. You can adjust the base URL
+by hooking into the `mhtp_typebot_embed_base` filter if your Typebot instance
+uses a different domain, such as `https://embed.typebot.io/`.
+
 ## Description
 MHTP Chat Interface is a WordPress plugin that provides a chat interface for experts with WooCommerce integration. This plugin allows users to chat with experts who are set up as WooCommerce products.
 

--- a/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
@@ -676,7 +676,8 @@ function mhtp_builtin_typebot_shortcode( $atts ) {
         'typebot'
     );
 
-    $src = 'https://typebot.io/' . $atts['typebot'];
+    $base = apply_filters( 'mhtp_typebot_embed_base', 'https://typebot.io/' );
+    $src  = trailingslashit( $base ) . $atts['typebot'];
     if ( ! empty( $atts['url_params'] ) ) {
         $src .= '?' . ltrim( $atts['url_params'], '?' );
     }


### PR DESCRIPTION
## Summary
- revert default Typebot embed base to `https://typebot.io/`
- update README accordingly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683c963894248325be275fc631a0faa0