### PR TITLE
Handle Typebot session termination

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/README.md
+++ b/mhtp-chat-woocommerce-v1.3.3-final/README.md
@@ -4,10 +4,14 @@
 built-in support for embedding a [Typebot](https://typebot.io) conversation
 directly. The separate `mhtp-typebot-chat` plugin is no longer required.
 
+The embed uses `https://embed.typebot.io/` by default. You can adjust the
+base URL by hooking into the `mhtp_typebot_embed_base` filter if your
+Typebot instance requires a different domain.
+
 ## Description
 MHTP Chat Interface is a WordPress plugin that provides a chat interface for experts with WooCommerce integration. This plugin allows users to chat with experts who are set up as WooCommerce products.
 
-**Note:** This version embeds a [Typebot](https://typebot.io) conversation instead of the previous Botpress-based chat UI while keeping the same page layout.
+**Note:** This version embeds a [Typebot](https://typebot.io) conversation instead of the previous Botpress-based chat UI while keeping the same page layout. When using Typebot the conversation transcript cannot be exported, so the "Descargar conversación" button is disabled.
 
 ## New in Version 1.3.0
 - **Unified Session Management**: Now properly decrements sessions when users start a chat, working with both test sessions (from MHTP Test Sessions plugin) and paid sessions (from WooCommerce)

--- a/mhtp-chat-woocommerce-v1.3.3-final/css/chat-interface.css
+++ b/mhtp-chat-woocommerce-v1.3.3-final/css/chat-interface.css
@@ -135,6 +135,30 @@
     display: flex;
     flex-direction: column;
     padding-left: 20px;
+    position: relative;
+}
+
+/* Overlay shown when the session ends */
+.mhtp-session-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(255, 255, 255, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.2rem;
+    font-weight: bold;
+    color: #333;
+    z-index: 10;
+    pointer-events: all;
+}
+
+.mhtp-chat-main.disabled iframe {
+    filter: grayscale(1);
+    pointer-events: none;
 }
 
 .mhtp-chat-messages {

--- a/mhtp-chat-woocommerce-v1.3.3-final/js/chat-interface.js
+++ b/mhtp-chat-woocommerce-v1.3.3-final/js/chat-interface.js
@@ -10,6 +10,8 @@ jQuery(document).ready(function($) {
     const cancelEndSessionButton = $('#mhtp-cancel-end-session');
     const saveConversationCheckbox = $('#mhtp-save-conversation');
     const downloadConversationButton = $('#mhtp-download-conversation');
+    const chatMain = $('.mhtp-chat-main');
+    const sessionOverlay = $('#mhtp-session-overlay');
     
     // Session variables
     let sessionActive = false; // Start as false until session is confirmed
@@ -18,6 +20,7 @@ jQuery(document).ready(function($) {
     let sessionEndTime;
     let conversationMessages = []; // Array to store all messages for saving
     let sessionStarted = false; // Track if session has been started with the server
+    const isTypebotOnly = chatMessages.length === 0 && chatInput.length === 0 && chatMain.find('iframe').length > 0;
     
     // Initialize chat
     function initChat() {
@@ -165,7 +168,12 @@ jQuery(document).ready(function($) {
         
         // Download conversation
         if (downloadConversationButton.length) {
-            downloadConversationButton.on('click', function() {
+            downloadConversationButton.on('click', function(e) {
+                if (isTypebotOnly) {
+                    e.preventDefault();
+                    alert('La descarga de la conversaci\u00f3n no est\u00e1 disponible con Typebot.');
+                    return;
+                }
                 if (conversationMessages.length > 0) {
                     generatePDF();
                 }
@@ -411,10 +419,16 @@ jQuery(document).ready(function($) {
     // End session
     function endSession() {
         if (!sessionActive) return;
-        
+
         sessionActive = false;
         clearInterval(sessionTimer);
-        
+
+        // If using the Typebot iframe only, grey it out
+        if (chatMain.find('iframe').length) {
+            chatMain.addClass('disabled');
+            sessionOverlay.show();
+        }
+
         // Disable input
         chatInput.prop('disabled', true);
         sendButton.prop('disabled', true);
@@ -441,6 +455,9 @@ jQuery(document).ready(function($) {
     // Check if we're on the chat interface page
     if (chatMessages.length > 0 && chatInput.length > 0) {
         initChat();
+    } else if (isTypebotOnly) {
+        sessionActive = true;
+        startSessionTimer();
     }
     
     // Add CSS for typing indicator and conversation saving

--- a/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
@@ -676,7 +676,8 @@ function mhtp_builtin_typebot_shortcode( $atts ) {
         'typebot'
     );
 
-    $src = 'https://typebot.io/' . $atts['typebot'];
+    $base = apply_filters( 'mhtp_typebot_embed_base', 'https://embed.typebot.io/' );
+    $src  = trailingslashit( $base ) . $atts['typebot'];
     if ( ! empty( $atts['url_params'] ) ) {
         $src .= '?' . ltrim( $atts['url_params'], '?' );
     }

--- a/mhtp-chat-woocommerce-v1.3.3-final/templates/chat-interface.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/templates/chat-interface.php
@@ -103,6 +103,9 @@ if (!defined('ABSPATH')) {
                 'url_params' => $query,
             ));
             ?>
+            <div id="mhtp-session-overlay" class="mhtp-session-overlay" style="display:none;">
+                Tu sesión ha concluido
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- disable chat iframe and show overlay when the session ends
- guard download conversation button when Typebot is used
- update styles for the overlay
- document that transcripts can't be exported with Typebot

## Testing
- `php -l mhtp-chat-woocommerce-v1.3.3-final/templates/chat-interface.php` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c963894248325be275fc631a0faa0