### PR TITLE
Add ExpertId param integration with Typebot

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/assets/js/mhtp-chat-init.js
+++ b/mhtp-chat-woocommerce-v1.3.3-final/assets/js/mhtp-chat-init.js
@@ -1,0 +1,35 @@
+(function(){
+    function getParam(name){
+        return new URLSearchParams(window.location.search).get(name);
+    }
+    function getExpertId(){
+        if(window.mhtpChatData && parseInt(window.mhtpChatData.ExpertId,10)){
+            return parseInt(window.mhtpChatData.ExpertId,10);
+        }
+        var fromUrl = getParam('ExpertId');
+        if(fromUrl){
+            return parseInt(fromUrl,10);
+        }
+        console.warn('ExpertId missing. Falling back to default 392');
+        return 392;
+    }
+    function init(){
+        var expertId = getExpertId();
+        if(!window.Typebot || typeof window.Typebot.initStandard !== 'function'){
+            console.error('Typebot library not loaded');
+            return;
+        }
+        try {
+            window.Typebot.initStandard({
+                variables:{ExpertId: expertId}
+            });
+        } catch(e){
+            console.error('Typebot initialization failed', e);
+        }
+    }
+    if(document.readyState === 'loading'){
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/mhtp-chat-woocommerce-v1.3.3-final/includes/class-mhtp-chat.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/includes/class-mhtp-chat.php
@@ -1,0 +1,34 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class MHTP_Chat {
+    public function __construct() {
+        add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+    }
+
+    public function enqueue_scripts() {
+        $expert_id = isset( $_GET['ExpertId'] ) ? absint( $_GET['ExpertId'] ) : 0;
+
+        wp_register_script(
+            'typebot-js',
+            'https://cdn.jsdelivr.net/npm/@typebot.io/js@0.2',
+            array(),
+            '0.2',
+            true
+        );
+        wp_enqueue_script( 'typebot-js' );
+
+        wp_register_script(
+            'mhtp-chat-init',
+            MHTP_CHAT_PLUGIN_URL . 'assets/js/mhtp-chat-init.js',
+            array( 'typebot-js' ),
+            MHTP_CHAT_VERSION,
+            true
+        );
+
+        wp_localize_script( 'mhtp-chat-init', 'mhtpChatData', array( 'ExpertId' => $expert_id ) );
+        wp_enqueue_script( 'mhtp-chat-init' );
+    }
+}

--- a/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
@@ -96,9 +96,14 @@ class MHTP_Chat_Interface {
     public function init() {
         // Load text domain for translations
         load_plugin_textdomain('mhtp-chat-interface', false, dirname(plugin_basename(__FILE__)) . '/languages');
-        
+
         // Include required files
         $this->includes();
+
+        // Instantiate the front-end chat integration after files are loaded
+        if ( class_exists( 'MHTP_Chat' ) ) {
+            new MHTP_Chat();
+        }
     }
     
     /**
@@ -110,6 +115,9 @@ class MHTP_Chat_Interface {
 
         // Include Typebot settings page
         require_once MHTP_CHAT_PLUGIN_DIR . 'includes/typebot-settings.php';
+
+        // Chat front-end integration
+        require_once MHTP_CHAT_PLUGIN_DIR . 'includes/class-mhtp-chat.php';
     }
     
     /**


### PR DESCRIPTION
## Summary
- add front-end Typebot loader class
- enqueue Typebot.js v0.2 and expose ExpertId via `wp_localize_script`
- create `mhtp-chat-init.js` to init Typebot using localized ExpertId
- include new class in plugin bootstrap
- load new class after `plugins_loaded` to prevent fatal error

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6846af63aa988325a3c7c9f1dd3cb129