### PR TITLE
Fix MHTP_Chat require

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
@@ -20,6 +20,7 @@ if (!defined('ABSPATH')) {
 // Define plugin constants
 define('MHTP_CHAT_VERSION', '3.1.0');
 define('MHTP_CHAT_PLUGIN_DIR', plugin_dir_path(__FILE__));
+require_once MHTP_CHAT_PLUGIN_DIR . 'includes/class-mhtp-chat.php';
 define('MHTP_CHAT_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('MHTP_CHAT_PLUGIN_FILE', __FILE__);
 // Botpress Chat API base URL (no trailing slash)


### PR DESCRIPTION
## Summary
- load the MHTP_Chat class immediately when the plugin loads

## Testing
- `php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b72d8c58832584b6d69fb3062cc7