### PR TITLE
Fix history rendering in chat interface

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/assets/js/chat-interface.js
+++ b/mhtp-chat-woocommerce-v1.3.3-final/assets/js/chat-interface.js
@@ -19,7 +19,7 @@
 
     // Load history from sessionStorage
     history = loadHistory();
-    history.forEach(renderMessage);
+    history.forEach(msg => appendMessage(msg.side, msg.text, msg.ts));
 
     // Hide loading bubble after 1-2s if no assistant message arrives
     loadingTimer = setTimeout(hideLoadingBubble, 1000 + Math.random()*1000);
@@ -49,9 +49,11 @@
   }
 
   function updateHistory(side, text){
-    history.push({ side, text, ts: Date.now() });
+    const ts = Date.now();
+    history.push({ side, text, ts });
     history = history.slice(-50);
     saveHistory();
+    appendMessage(side, text, ts);
   }
 
   function hideLoadingBubble(){
@@ -76,7 +78,6 @@
 
   async function sendMessage(text){
     updateHistory('user', text);
-    renderMessage({ side: 'user', text });
 
     try{
       const res = await fetch('/wp-json/mhtp-chat/send', {
@@ -97,7 +98,6 @@
 
   function receiveMessage(text){
     updateHistory('assistant', text);
-    renderMessage({ side: 'assistant', text });
   }
 
   // Expose send/receive if needed


### PR DESCRIPTION
## Summary
- initialize chat messages by passing stored history to `appendMessage`
- append new messages via `appendMessage` when updating history
- avoid duplicate rendering from `sendMessage` and `receiveMessage`

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68547a23461c83259ed6909486616722