### PR TITLE
Fix history update on message add

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/js/chat-interface.js
+++ b/mhtp-chat-woocommerce-v1.3.3-final/js/chat-interface.js
@@ -307,7 +307,6 @@ jQuery(document).ready(function($) {
             // Add message to chat immediately
             addMessage(message, 'user');
             storeMessage(message, 'user', getCurrentTime());
-            updateHistory('user', message);
             chatInput.val('');
 
             fetch(mhtpChatConfig.rest_url, {
@@ -324,7 +323,6 @@ jQuery(document).ready(function($) {
                     if (data.text) {
                         addMessage(data.text, 'expert');
                         storeMessage(data.text, 'expert', getCurrentTime());
-                        updateHistory('expert', data.text);
                         hideLoadingBubble();
                     } else if (data.error) {
                         addSystemMessage('Error: ' + data.error);
@@ -363,6 +361,7 @@ jQuery(document).ready(function($) {
         
         // Scroll to bottom
         scrollToBottom();
+        updateHistory(sender, message);
     }
     
     // Add system message


### PR DESCRIPTION
## Summary
- update chat history whenever a message is added
- remove redundant history updates in send logic

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6854823b82588325a00c06b65d8875ba