### PR TITLE
Fix message history caching when session starts

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/js/chat-interface.js
+++ b/mhtp-chat-woocommerce-v1.3.3-final/js/chat-interface.js
@@ -18,7 +18,7 @@ jQuery(document).ready(function($) {
     let chatHistory = [];
     let loadingBubble = null;
     let loadingTimer = null;
-    
+
     // Session variables
     let sessionActive = false; // Start as false until session is confirmed
     let sessionDuration = 45 * 60; // 45 minutes in seconds
@@ -121,7 +121,7 @@ jQuery(document).ready(function($) {
         if (side === 'expert') hideLoadingBubble();
         scrollToBottom();
     }
-    
+
     // Initialize chat
     function initChat() {
         // Get expert ID and session ID
@@ -147,7 +147,7 @@ jQuery(document).ready(function($) {
             startSessionWithServer(expertId, sessionId);
         }
     }
-    
+
     // Get expert ID from the page
     function getExpertId() {
         // Try to get from URL parameter
@@ -155,7 +155,7 @@ jQuery(document).ready(function($) {
         if (urlParams.has('expert_id')) {
             return urlParams.get('expert_id');
         }
-        
+
         // If not in URL, try to extract from the page
         const expertLink = $('.mhtp-expert-info').closest('a');
         if (expertLink.length && expertLink.attr('href')) {
@@ -164,10 +164,10 @@ jQuery(document).ready(function($) {
                 return hrefParams.get('expert_id');
             }
         }
-        
+
         return null;
     }
-    
+
     // Get session ID from the page
     function getSessionId() {
         const sessionIdElement = $('.mhtp-session-info .mhtp-session-detail:first-child .mhtp-session-value');
@@ -176,12 +176,12 @@ jQuery(document).ready(function($) {
         }
         return null;
     }
-    
+
     // Start session with server via AJAX
     function startSessionWithServer(expertId, sessionId) {
         // Show loading message
         addSystemMessage('Iniciando sesión, por favor espera...');
-        
+
         // Make AJAX call to start session
         $.ajax({
             url: mhtpChat.ajaxurl,
@@ -197,30 +197,30 @@ jQuery(document).ready(function($) {
                     // Session started successfully
                     sessionStarted = true;
                     sessionActive = true;
-                    
+
                     // Remove loading message
                     $('.mhtp-message-system').remove();
-                    
+
                     // Set session end time
                     sessionEndTime = new Date();
                     sessionEndTime.setMinutes(sessionEndTime.getMinutes() + 45);
                     saveSessionState(expertId, sessionId, sessionEndTime.getTime());
-                    
+
                     // Start session timer
                     startSessionTimer();
-                    
+
                     // Focus on input
                     chatInput.focus();
-                    
+
                     // Set up event listeners
                     setupEventListeners();
-                    
+
                     // Store initial welcome message
                     const welcomeMessage = $('.mhtp-message-expert').first().find('.mhtp-message-content p').text();
                     storeMessage(welcomeMessage, 'expert', getCurrentTime());
                     updateHistory('expert', welcomeMessage);
                     hideLoadingBubble();
-                    
+
                     // Add success message
                     addSystemMessage('Sesión iniciada correctamente. ¡Bienvenido!');
                 } else {
@@ -234,16 +234,16 @@ jQuery(document).ready(function($) {
             }
         });
     }
-    
+
     // Handle session error
     function handleSessionError(errorMessage) {
         // Show error message
         addSystemMessage('Error: ' + errorMessage);
-        
+
         // Disable chat input
         chatInput.prop('disabled', true);
         sendButton.prop('disabled', true);
-        
+
         // Change end session button to return button
         endSessionButton.text('Volver al inicio');
         endSessionButton.removeClass('mhtp-end-session-button').addClass('mhtp-return-button');
@@ -251,12 +251,12 @@ jQuery(document).ready(function($) {
             window.location.href = window.location.pathname;
         });
     }
-    
+
     // Set up event listeners
     function setupEventListeners() {
         // Send message on button click
         sendButton.on('click', sendMessage);
-        
+
         // Send message on Enter key (but allow Shift+Enter for new line)
         chatInput.on('keydown', function(e) {
             if (e.key === 'Enter' && !e.shiftKey) {
@@ -264,21 +264,21 @@ jQuery(document).ready(function($) {
                 sendMessage();
             }
         });
-        
+
         // End session button - show confirmation modal
         endSessionButton.on('click', showEndSessionConfirmation);
-        
+
         // Confirm end session
         confirmEndSessionButton.on('click', function() {
             endSessionModal.hide();
             endSession();
         });
-        
+
         // Cancel end session
         cancelEndSessionButton.on('click', function() {
             endSessionModal.hide();
         });
-        
+
         // Download conversation
         if (downloadConversationButton.length) {
             downloadConversationButton.on('click', function(e) {
@@ -293,17 +293,17 @@ jQuery(document).ready(function($) {
             });
         }
     }
-    
+
     // Show end session confirmation modal
     function showEndSessionConfirmation() {
         endSessionModal.css('display', 'block');
     }
-    
+
     // Send message function
     function sendMessage() {
         const message = chatInput.val().trim();
 
-        if (message && sessionActive) {
+        if (message) {
             // Add message to chat immediately
             addMessage(message, 'user');
             storeMessage(message, 'user', getCurrentTime());
@@ -333,7 +333,7 @@ jQuery(document).ready(function($) {
                 );
         }
     }
-    
+
     // Store message for saving
     function storeMessage(message, sender, time) {
         conversationMessages.push({
@@ -342,96 +342,96 @@ jQuery(document).ready(function($) {
             time: time
         });
     }
-    
+
     // Add message to chat
     function addMessage(message, sender) {
         const messageElement = $('<div class="mhtp-message"></div>');
         messageElement.addClass(sender === 'user' ? 'mhtp-message-user' : 'mhtp-message-expert');
-        
+
         const contentElement = $('<div class="mhtp-message-content"></div>');
         contentElement.html('<p>' + message.replace(/\n/g, '<br>') + '</p>');
-        
+
         const timeElement = $('<div class="mhtp-message-time"></div>');
         timeElement.text(getCurrentTime());
-        
+
         messageElement.append(contentElement);
         messageElement.append(timeElement);
-        
+
         chatMessages.append(messageElement);
-        
+
         // Scroll to bottom
         scrollToBottom();
         updateHistory(sender, message);
     }
-    
+
     // Add system message
     function addSystemMessage(message) {
         const messageElement = $('<div class="mhtp-message mhtp-message-system"></div>');
         const contentElement = $('<div class="mhtp-message-content mhtp-system-content"></div>');
         contentElement.html('<p>' + message + '</p>');
-        
+
         messageElement.append(contentElement);
         chatMessages.append(messageElement);
-        
+
         // Store system message for saving
         storeMessage(message, 'system', getCurrentTime());
-        
+
         // Scroll to bottom
         scrollToBottom();
     }
-    
+
     // Simulate typing indicator with improved visuals
     function simulateTyping() {
         // Get expert avatar URL
         const expertAvatarUrl = $('.mhtp-expert-avatar img').attr('src');
         const expertName = $('.mhtp-expert-name').text();
-        
+
         // Create typing indicator with avatar
         const typingElement = $('<div class="mhtp-message mhtp-message-expert mhtp-typing-indicator"></div>');
-        
+
         // Add avatar if available
         if (expertAvatarUrl) {
             const avatarElement = $('<div class="mhtp-typing-avatar"></div>');
             avatarElement.html('<img src="' + expertAvatarUrl + '" alt="' + expertName + '">');
             typingElement.append(avatarElement);
         }
-        
+
         // Add typing animation
         const contentElement = $('<div class="mhtp-message-content mhtp-typing-content"></div>');
         contentElement.html('<div class="mhtp-typing-bubbles"><div class="mhtp-typing-bubble"></div><div class="mhtp-typing-bubble"></div><div class="mhtp-typing-bubble"></div></div>');
-        
+
         typingElement.append(contentElement);
         chatMessages.append(typingElement);
-        
+
         // Scroll to bottom
         scrollToBottom();
     }
-    
+
     // Get current time in HH:MM format
     function getCurrentTime() {
         const now = new Date();
         let hours = now.getHours();
         let minutes = now.getMinutes();
-        
+
         hours = hours < 10 ? '0' + hours : hours;
         minutes = minutes < 10 ? '0' + minutes : minutes;
-        
+
         return hours + ':' + minutes;
     }
-    
+
     // Scroll chat to bottom
     function scrollToBottom() {
         chatMessages.scrollTop(chatMessages[0].scrollHeight);
     }
-    
+
     // Format time as MM:SS
     function formatTime(seconds) {
         const minutes = Math.floor(seconds / 60);
         const remainingSeconds = seconds % 60;
-        
+
         return (minutes < 10 ? '0' : '') + minutes + ':' + (remainingSeconds < 10 ? '0' : '') + remainingSeconds;
     }
-    
+
     // Start session timer
     function startSessionTimer() {
         function update() {
@@ -445,7 +445,7 @@ jQuery(document).ready(function($) {
             if (timeLeft <= 5 * 60) {
                 sessionTimerElement.addClass('warning');
             }
-            
+
             // Check for warnings
             if (timeLeft === 10 * 60) { // 10 minutes left
                 addSystemMessage('Quedan 10 minutos para finalizar la sesión.');
@@ -461,7 +461,7 @@ jQuery(document).ready(function($) {
         update();
         sessionTimer = setInterval(update, 1000);
     }
-    
+
     // Generate PDF of conversation
     function generatePDF() {
         // Check if jsPDF is loaded
@@ -477,59 +477,59 @@ jQuery(document).ready(function($) {
             generatePDFContent();
         }
     }
-    
+
     // Generate PDF content
     function generatePDFContent() {
         const { jsPDF } = window.jspdf;
         const doc = new jsPDF();
-        
+
         // Get expert and session info
         const expertName = $('.mhtp-expert-name').text();
         const expertSpecialty = $('.mhtp-expert-specialty').text();
         const sessionId = $('.mhtp-session-info .mhtp-session-detail:first-child .mhtp-session-value').text();
         const sessionDate = new Date().toLocaleDateString();
-        
+
         // Set title
         doc.setFontSize(18);
         doc.text('Resumen de Consulta con Experto', 105, 20, { align: 'center' });
-        
+
         // Set session info
         doc.setFontSize(12);
         doc.text(`Experto: ${expertName} - ${expertSpecialty}`, 20, 40);
         doc.text(`ID de Sesión: ${sessionId}`, 20, 50);
         doc.text(`Fecha: ${sessionDate}`, 20, 60);
-        
+
         // Add conversation
         doc.setFontSize(11);
         let yPos = 80;
-        
+
         conversationMessages.forEach(function(msg) {
             const sender = msg.sender === 'user' ? 'Tú' : (msg.sender === 'expert' ? expertName : 'Sistema');
             const prefix = msg.sender === 'user' ? '→ ' : (msg.sender === 'expert' ? '← ' : '! ');
-            
+
             // Check if we need a new page
             if (yPos > 270) {
                 doc.addPage();
                 yPos = 20;
             }
-            
+
             doc.setFont(undefined, msg.sender === 'system' ? 'bold' : 'normal');
             doc.text(`${prefix}${sender} (${msg.time}): ${msg.message}`, 20, yPos, {
                 maxWidth: 170
             });
-            
+
             // Calculate height of text to position next message
             const textHeight = doc.getTextDimensions(`${prefix}${sender} (${msg.time}): ${msg.message}`, {
                 maxWidth: 170
             }).h;
-            
+
             yPos += textHeight + 5;
         });
-        
+
         // Save PDF
         doc.save(`Chat_con_${expertName.replace(/\s+/g, '_')}_${sessionId}.pdf`);
     }
-    
+
     // End session
     function endSession() {
         if (!sessionActive) return;
@@ -547,26 +547,26 @@ jQuery(document).ready(function($) {
         // Disable input
         chatInput.prop('disabled', true);
         sendButton.prop('disabled', true);
-        
+
         // Change end session button
         endSessionButton.text('Volver al inicio');
         endSessionButton.removeClass('mhtp-end-session-button').addClass('mhtp-return-button');
         endSessionButton.off('click').on('click', function() {
             window.location.href = window.location.pathname;
         });
-        
+
         // Update session status
         $('.mhtp-session-active').text('Finalizada').removeClass('mhtp-session-active').addClass('mhtp-session-ended');
-        
+
         // Add system message
         addSystemMessage('La sesión ha finalizado. Gracias por utilizar nuestro servicio de chat con expertos.');
-        
+
         // Enable download button if conversation saving is checked
         if (saveConversationCheckbox.is(':checked')) {
             downloadConversationButton.prop('disabled', false);
         }
     }
-    
+
     // Check if we're on the full chat interface (Botpress) page
     if (chatMessages.length > 0 && chatInput.length > 0) {
         initChat();
@@ -586,7 +586,7 @@ jQuery(document).ready(function($) {
         setupEventListeners();
         startSessionTimer();
     }
-    
+
     // Add CSS for typing indicator and conversation saving
     $('<style>')
         .prop('type', 'text/css')
@@ -597,19 +597,19 @@ jQuery(document).ready(function($) {
                 align-items: flex-start;
                 margin-bottom: 15px;
             }
-            
+
             .mhtp-typing-avatar {
                 margin-right: 10px;
                 flex-shrink: 0;
             }
-            
+
             .mhtp-typing-avatar img {
                 width: 36px;
                 height: 36px;
                 border-radius: 50%;
                 border: 2px solid #3a5998;
             }
-            
+
             .mhtp-typing-content {
                 background-color: #e9eef5;
                 border-radius: 18px;
@@ -619,13 +619,13 @@ jQuery(document).ready(function($) {
                 min-width: 60px;
                 min-height: 24px;
             }
-            
+
             .mhtp-typing-bubbles {
                 display: flex;
                 justify-content: center;
                 align-items: center;
             }
-            
+
             .mhtp-typing-bubble {
                 background-color: #3a5998;
                 border-radius: 50%;
@@ -634,19 +634,19 @@ jQuery(document).ready(function($) {
                 margin: 0 2px;
                 animation: mhtp-typing-bubble-animation 1.2s infinite ease-in-out;
             }
-            
+
             .mhtp-typing-bubble:nth-child(1) {
                 animation-delay: 0s;
             }
-            
+
             .mhtp-typing-bubble:nth-child(2) {
                 animation-delay: 0.2s;
             }
-            
+
             .mhtp-typing-bubble:nth-child(3) {
                 animation-delay: 0.4s;
             }
-            
+
             @keyframes mhtp-typing-bubble-animation {
                 0%, 60%, 100% {
                     transform: translateY(0);
@@ -655,13 +655,13 @@ jQuery(document).ready(function($) {
                     transform: translateY(-6px);
                 }
             }
-            
+
             /* System message styles */
             .mhtp-message-system {
                 margin: 10px 0;
                 text-align: center;
             }
-            
+
             .mhtp-system-content {
                 display: inline-block;
                 background-color: #f8f9fa;
@@ -671,7 +671,7 @@ jQuery(document).ready(function($) {
                 color: #666;
                 box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
             }
-            
+
             /* Conversation saving styles */
             .mhtp-conversation-options {
                 margin-top: 15px;
@@ -680,11 +680,11 @@ jQuery(document).ready(function($) {
                 padding: 15px;
                 box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
             }
-            
+
             .mhtp-conversation-option {
                 margin-bottom: 10px;
             }
-            
+
             .mhtp-conversation-option label {
                 display: flex;
                 align-items: center;
@@ -692,11 +692,11 @@ jQuery(document).ready(function($) {
                 color: #333;
                 cursor: pointer;
             }
-            
+
             .mhtp-conversation-option input[type="checkbox"] {
                 margin-right: 8px;
             }
-            
+
             .mhtp-download-button {
                 width: 100%;
                 padding: 8px;
@@ -708,11 +708,11 @@ jQuery(document).ready(function($) {
                 font-size: 0.9rem;
                 transition: background-color 0.2s;
             }
-            
+
             .mhtp-download-button:hover {
                 background-color: #2d4373;
             }
-            
+
             .mhtp-download-button:disabled {
                 background-color: #cccccc;
                 cursor: not-allowed;


### PR DESCRIPTION
## Summary
- keep `withChat` history replay
- allow messages to cache before session is active
- format JS file

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_685486150a5c83259489ca050a248032