### PR TITLE
Add user ID to Typebot variables

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/README.md
+++ b/mhtp-chat-woocommerce-v1.3.3-final/README.md
@@ -1,4 +1,4 @@
-# MHTP Chat Interface - Version 3.1.0
+# MHTP Chat Interface - Version 3.1.1
 
 **Note:** This plugin was originally built for Botpress. It now includes
 built-in support for embedding a [Typebot](https://typebot.io) conversation

--- a/mhtp-chat-woocommerce-v1.3.3-final/assets/js/mhtp-chat-init.js
+++ b/mhtp-chat-woocommerce-v1.3.3-final/assets/js/mhtp-chat-init.js
@@ -22,10 +22,25 @@
     }
 
     /**
+     * Get the current user identifier (email) if available.
+     */
+    function getUserId() {
+        if (window.mhtpChatData && window.mhtpChatData.UserId) {
+            return window.mhtpChatData.UserId;
+        }
+        var fromUrl = getParam('UserId');
+        if (fromUrl) {
+            return fromUrl;
+        }
+        return '';
+    }
+
+    /**
      * Initialise the Typebot widget and attach the end chat handler.
      */
     function init() {
         var expertId = getExpertId();
+        var userId = getUserId();
 
         // Support both "Typebot" and "typebot" globals just in case.
         var TB = window.Typebot || window.typebot;
@@ -37,7 +52,7 @@
 
         try {
             TB.initStandard({
-                variables: { ExpertId: expertId }
+                variables: { ExpertId: expertId, UserId: userId }
             });
 
             // Ensure Typebot is accessible globally for later commands

--- a/mhtp-chat-woocommerce-v1.3.3-final/includes/class-mhtp-chat.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/includes/class-mhtp-chat.php
@@ -9,7 +9,9 @@ class MHTP_Chat {
     }
 
     public function enqueue_scripts() {
-        $expert_id = isset( $_GET['ExpertId'] ) ? absint( $_GET['ExpertId'] ) : 0;
+        $expert_id  = isset( $_GET['ExpertId'] ) ? absint( $_GET['ExpertId'] ) : 0;
+        $user       = wp_get_current_user();
+        $user_email = ( $user instanceof WP_User ) ? $user->user_email : '';
 
         wp_register_script(
             'typebot-js',
@@ -28,7 +30,14 @@ class MHTP_Chat {
             true
         );
 
-        wp_localize_script( 'mhtp-chat-init', 'mhtpChatData', array( 'ExpertId' => $expert_id ) );
+        wp_localize_script(
+            'mhtp-chat-init',
+            'mhtpChatData',
+            array(
+                'ExpertId' => $expert_id,
+                'UserId'   => $user_email,
+            )
+        );
         wp_enqueue_script( 'mhtp-chat-init' );
     }
 }

--- a/mhtp-chat-woocommerce-v1.3.3-final/includes/typebot-settings.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/includes/typebot-settings.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class MHTP_Typebot_Settings {
 
-    private $params = array( 'ExpertId', 'ExpertName', 'Topic', 'HistoryEnabled', 'IsClient' );
+    private $params = array( 'ExpertId', 'ExpertName', 'Topic', 'HistoryEnabled', 'IsClient', 'UserId' );
 
     public function __construct() {
         add_action( 'admin_menu', array( $this, 'add_admin_menu' ) );
@@ -70,7 +70,7 @@ class MHTP_Typebot_Settings {
     public function param_count_render() {
         $options = get_option( 'mhtp_typebot_options' );
         $count   = isset( $options['param_count'] ) ? intval( $options['param_count'] ) : 1;
-        echo '<input id="param_count" type="number" name="mhtp_typebot_options[param_count]" value="' . esc_attr( $count ) . '" min="1" max="5" required>';
+        echo '<input id="param_count" type="number" name="mhtp_typebot_options[param_count]" value="' . esc_attr( $count ) . '" min="1" max="6" required>';
     }
 
     public function selected_params_render() {
@@ -86,7 +86,7 @@ class MHTP_Typebot_Settings {
     public function sanitize( $input ) {
         $output                  = array();
         $output['chatbot_url']   = isset( $input['chatbot_url'] ) ? esc_url_raw( $input['chatbot_url'] ) : '';
-        $output['param_count']   = isset( $input['param_count'] ) ? max( 1, min( 5, intval( $input['param_count'] ) ) ) : 1;
+        $output['param_count']   = isset( $input['param_count'] ) ? max( 1, min( 6, intval( $input['param_count'] ) ) ) : 1;
         $output['selected_params'] = array();
         if ( ! empty( $input['selected_params'] ) && is_array( $input['selected_params'] ) ) {
             foreach ( $input['selected_params'] as $param ) {

--- a/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
@@ -3,7 +3,7 @@
  * Plugin Name: MHTP Chat Interface
  * Plugin URI: https://mhtp.com
  * Description: Chat interface for Mental Health Triage Platform using Typebot
- * Version: 3.1.0
+ * Version: 3.1.1
  * Author: MHTP Team
  * Author URI: https://mhtp.com
  * Text Domain: mhtp-chat-interface
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('MHTP_CHAT_VERSION', '3.1.0');
+define('MHTP_CHAT_VERSION', '3.1.1');
 define('MHTP_CHAT_PLUGIN_DIR', plugin_dir_path(__FILE__));
 require_once MHTP_CHAT_PLUGIN_DIR . 'includes/class-mhtp-chat.php';
 define('MHTP_CHAT_PLUGIN_URL', plugin_dir_url(__FILE__));

--- a/mhtp-chat-woocommerce-v1.3.3-final/templates/chat-interface.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/templates/chat-interface.php
@@ -91,12 +91,14 @@ if (!defined('ABSPATH')) {
             $url      = !empty($cfg['chatbot_url']) ? $cfg['chatbot_url'] : 'https://typebot.io/especialista-5gzhab4';
             $selected = isset($cfg['selected_params']) && is_array($cfg['selected_params']) ? $cfg['selected_params'] : array();
 
-            $available = array(
+            $current_user = wp_get_current_user();
+            $available    = array(
                 'ExpertId'       => $expert_id,
                 'ExpertName'     => !empty($expert['name']) ? $expert['name'] : '',
                 'Topic'          => isset($_GET['topic']) ? sanitize_text_field($_GET['topic']) : '',
                 'HistoryEnabled' => '1',
                 'IsClient'       => isset($_GET['is_client']) ? sanitize_text_field($_GET['is_client']) : '',
+                'UserId'         => $current_user instanceof WP_User ? $current_user->user_email : '',
             );
 
             $params = array();


### PR DESCRIPTION
## Summary
- include `UserId` as an optional Typebot parameter
- expose the current user's email to the front end
- pass `UserId` to Typebot widget initialization
- bump plugin version to 3.1.1

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a821c966c8325a56b71b3a8f5f4bf