### PR TITLE
Fix Typebot end-chat button

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/README.md
+++ b/mhtp-chat-woocommerce-v1.3.3-final/README.md
@@ -1,4 +1,4 @@
-# MHTP Chat Interface - Version 3.1.1
+# MHTP Chat Interface - Version 3.1.2
 
 **Note:** This plugin was originally built for Botpress. It now includes
 built-in support for embedding a [Typebot](https://typebot.io) conversation
@@ -73,6 +73,9 @@ This plugin now properly handles session decrementation when users start a chat:
 3. If no sessions of either type are available, the user receives an error message
 
 ## Changelog
+
+### 3.1.2
+❇ Fixed end-chat button id so store-conversation command is sent to Typebot.
 
 ### 3.0.0
 - Switched to Botpress Cloud's official Chat API using `conversations.getOrCreate` and `messages`.

--- a/mhtp-chat-woocommerce-v1.3.3-final/assets/js/mhtp-chat-init.js
+++ b/mhtp-chat-woocommerce-v1.3.3-final/assets/js/mhtp-chat-init.js
@@ -62,23 +62,6 @@
             return;
         }
 
-        // Listen for the end chat button to trigger storing the conversation
-        var endBtn = document.getElementById('end-chat-btn');
-        if (endBtn) {
-            endBtn.addEventListener('click', async function () {
-                if (!window.Typebot || typeof window.Typebot.sendCommand !== 'function') {
-                    console.error('Typebot.sendCommand is unavailable.');
-                    return;
-                }
-                try {
-                    await window.Typebot.sendCommand({ command: 'store-conversation' });
-                } catch (error) {
-                    console.error('Failed to send store-conversation command to Typebot:', error);
-                }
-            });
-        } else {
-            console.error('End chat button with ID end-chat-btn not found.');
-        }
     }
 
     if (document.readyState === 'loading') {
@@ -87,3 +70,16 @@
         init();
     }
 })();
+
+// Ensure the end-chat handler is attached once the DOM is ready
+document.addEventListener('DOMContentLoaded', () => {
+    const btn = document.getElementById('mhtp-end-session');
+    btn?.addEventListener('click', async () => {
+        console.log('End-chat click');
+        try {
+            await Typebot.sendCommand({ command: 'store-conversation' });
+        } catch (e) {
+            console.error('Typebot command failed:', e);
+        }
+    });
+});

--- a/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
@@ -3,7 +3,7 @@
  * Plugin Name: MHTP Chat Interface
  * Plugin URI: https://mhtp.com
  * Description: Chat interface for Mental Health Triage Platform using Typebot
- * Version: 3.1.1
+ * Version: 3.1.2
  * Author: MHTP Team
  * Author URI: https://mhtp.com
  * Text Domain: mhtp-chat-interface
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('MHTP_CHAT_VERSION', '3.1.1');
+define('MHTP_CHAT_VERSION', '3.1.2');
 define('MHTP_CHAT_PLUGIN_DIR', plugin_dir_path(__FILE__));
 require_once MHTP_CHAT_PLUGIN_DIR . 'includes/class-mhtp-chat.php';
 define('MHTP_CHAT_PLUGIN_URL', plugin_dir_url(__FILE__));


### PR DESCRIPTION
## Summary
- update plugin version to 3.1.2
- document new version and changelog entry
- hook end-chat button using `mhtp-end-session` id

## Testing
- `npm test` *(fails: missing `package.json`)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685abddcde4083258cb1bf3b1163b077