### PR TITLE
Remove legacy end-chat JS; v3.1.5

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/README.md
+++ b/mhtp-chat-woocommerce-v1.3.3-final/README.md
@@ -1,4 +1,4 @@
-# MHTP Chat Interface - Version 3.1.4
+# MHTP Chat Interface - Version 3.1.5
 
 **Note:** This plugin was originally built for Botpress. It now includes
 built-in support for embedding a [Typebot](https://typebot.io) conversation
@@ -76,6 +76,9 @@ This plugin now properly handles session decrementation when users start a chat:
 
 ### 3.1.4
 * Load Typebot UMD widget and send store-conversation on session end. No other changes.
+
+### 3.1.5
+Removed legacy end-chat JS; no more 'Typebot not defined' error.
 
 ### 3.1.3
 * Added official Typebot JS SDK so sendCommand works; no other changes.

--- a/mhtp-chat-woocommerce-v1.3.3-final/assets/js/mhtp-chat-init.js
+++ b/mhtp-chat-woocommerce-v1.3.3-final/assets/js/mhtp-chat-init.js
@@ -72,14 +72,15 @@
 })();
 
 // Ensure the end-chat handler is attached once the DOM is ready
-document.addEventListener('DOMContentLoaded', () => {
-    const btn = document.getElementById('mhtp-end-session');
-    btn?.addEventListener('click', async () => {
-        console.log('End-chat click');
-        try {
-            await Typebot.sendCommand({ command: 'store-conversation' });
-        } catch (e) {
-            console.error('Typebot command failed:', e);
-        }
-    });
-});
+// Legacy end-chat handler (replaced by widget-ready snippet in template)
+// document.addEventListener('DOMContentLoaded', () => {
+//     const btn = document.getElementById('mhtp-end-session');
+//     btn?.addEventListener('click', async () => {
+//         console.log('End-chat click');
+//         try {
+//             await Typebot.sendCommand({ command: 'store-conversation' });
+//         } catch (e) {
+//             console.error('Typebot command failed:', e);
+//         }
+//     });
+// });

--- a/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
@@ -3,7 +3,7 @@
  * Plugin Name: MHTP Chat Interface
  * Plugin URI: https://mhtp.com
  * Description: Chat interface for Mental Health Triage Platform using Typebot
- * Version: 3.1.4
+ * Version: 3.1.5
  * Author: MHTP Team
  * Author URI: https://mhtp.com
  * Text Domain: mhtp-chat-interface
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('MHTP_CHAT_VERSION', '3.1.4');
+define('MHTP_CHAT_VERSION', '3.1.5');
 define('MHTP_CHAT_PLUGIN_DIR', plugin_dir_path(__FILE__));
 require_once MHTP_CHAT_PLUGIN_DIR . 'includes/class-mhtp-chat.php';
 define('MHTP_CHAT_PLUGIN_URL', plugin_dir_url(__FILE__));


### PR DESCRIPTION
## Summary
- comment out old end-chat click handler
- bump plugin version to 3.1.5
- document changelog entry

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b0caac30c8325b6b6fbf28a37071d