### PR TITLE
Fix Typebot embed domain

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/README.md
+++ b/mhtp-chat-woocommerce-v1.3.3-final/README.md
@@ -1,4 +1,4 @@
-# MHTP Chat Interface - Version 3.1.6
+# MHTP Chat Interface - Version 3.1.7
 
 **Note:** This plugin was originally built for Botpress. It now includes
 built-in support for embedding a [Typebot](https://typebot.io) conversation
@@ -73,6 +73,9 @@ This plugin now properly handles session decrementation when users start a chat:
 3. If no sessions of either type are available, the user receives an error message
 
 ## Changelog
+
+### 3.1.7
+* Force embed URL to https://typebot.co to load widget.
 
 ### 3.1.6
 * Fixed race condition causing `scrollToBottom` to run before the chat container existed.

--- a/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
@@ -3,7 +3,7 @@
  * Plugin Name: MHTP Chat Interface
  * Plugin URI: https://mhtp.com
  * Description: Chat interface for Mental Health Triage Platform using Typebot
- * Version: 3.1.6
+ * Version: 3.1.7
  * Author: MHTP Team
  * Author URI: https://mhtp.com
  * Text Domain: mhtp-chat-interface
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('MHTP_CHAT_VERSION', '3.1.6');
+define('MHTP_CHAT_VERSION', '3.1.7');
 define('MHTP_CHAT_PLUGIN_DIR', plugin_dir_path(__FILE__));
 require_once MHTP_CHAT_PLUGIN_DIR . 'includes/class-mhtp-chat.php';
 define('MHTP_CHAT_PLUGIN_URL', plugin_dir_url(__FILE__));
@@ -28,6 +28,14 @@ if (!defined('MHTP_CHAT_ENABLE_LOG')) {
 }
 // Botpress Chat API base URL (no trailing slash)
 define('MHTP_BOTPRESS_CHAT_API', 'https://chat.botpress.cloud/v1');
+
+// Force the Typebot embed to use the .co domain
+add_filter(
+    'mhtp_typebot_embed_base',
+    static function () {
+        return 'https://typebot.co/';
+    }
+);
 
 /*
  * ID of your Botpress Cloud bot. Define in wp-config.php as


### PR DESCRIPTION
## Summary
- ensure Typebot embed always loads from typebot.co
- bump version to 3.1.7
- document the new version and change

## Testing
- `php -l mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1a8202008325b89dc6bed924e854