### PR TITLE
Load Typebot widget before init script

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/README.md
+++ b/mhtp-chat-woocommerce-v1.3.3-final/README.md
@@ -1,4 +1,4 @@
-# MHTP Chat Interface - Version 3.1.7
+# MHTP Chat Interface - Version 3.1.8
 
 **Note:** This plugin was originally built for Botpress. It now includes
 built-in support for embedding a [Typebot](https://typebot.io) conversation
@@ -73,6 +73,10 @@ This plugin now properly handles session decrementation when users start a chat:
 3. If no sessions of either type are available, the user receives an error message
 
 ## Changelog
+
+### 3.1.8
+* Force load Typebot widget runtime after iframe
+* Ensure init script waits for window.TypebotWidget
 
 ### 3.1.7
 * Force embed URL to https://typebot.co to load widget.

--- a/mhtp-chat-woocommerce-v1.3.3-final/assets/js/mhtp-chat-init.js
+++ b/mhtp-chat-woocommerce-v1.3.3-final/assets/js/mhtp-chat-init.js
@@ -43,10 +43,10 @@
         var userId = getUserId();
 
         // Support both "Typebot" and "typebot" globals just in case.
-        var TB = window.Typebot || window.typebot;
+        var TB = window.TypebotWidget;
 
         if (!TB || typeof TB.initStandard !== 'function') {
-            console.error('Typebot library not loaded');
+            console.error('TypebotWidget not loaded');
             return;
         }
 
@@ -64,10 +64,18 @@
 
     }
 
+    function waitForWidget() {
+        if (window.TypebotWidget) {
+            init();
+        } else {
+            setTimeout(waitForWidget, 50);
+        }
+    }
+
     if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', init);
+        document.addEventListener('DOMContentLoaded', waitForWidget);
     } else {
-        init();
+        waitForWidget();
     }
 })();
 

--- a/mhtp-chat-woocommerce-v1.3.3-final/includes/class-mhtp-chat.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/includes/class-mhtp-chat.php
@@ -13,10 +13,18 @@ class MHTP_Chat {
         $user       = wp_get_current_user();
         $user_email = ( $user instanceof WP_User ) ? $user->user_email : '';
 
+        wp_enqueue_script(
+            'mhtp-typebot-widget',
+            'https://cdn.typebot.co/widget.js',
+            array(),
+            null,
+            true
+        );
+
         wp_register_script(
             'mhtp-chat-init',
             MHTP_CHAT_PLUGIN_URL . 'assets/js/mhtp-chat-init.js',
-            array(),
+            array( 'jquery', 'mhtp-typebot-widget' ),
             MHTP_CHAT_VERSION,
             true
         );

--- a/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
@@ -3,7 +3,7 @@
  * Plugin Name: MHTP Chat Interface
  * Plugin URI: https://mhtp.com
  * Description: Chat interface for Mental Health Triage Platform using Typebot
- * Version: 3.1.7
+ * Version: 3.1.8
  * Author: MHTP Team
  * Author URI: https://mhtp.com
  * Text Domain: mhtp-chat-interface
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('MHTP_CHAT_VERSION', '3.1.7');
+define('MHTP_CHAT_VERSION', '3.1.8');
 define('MHTP_CHAT_PLUGIN_DIR', plugin_dir_path(__FILE__));
 require_once MHTP_CHAT_PLUGIN_DIR . 'includes/class-mhtp-chat.php';
 define('MHTP_CHAT_PLUGIN_URL', plugin_dir_url(__FILE__));

--- a/mhtp-chat-woocommerce-v1.3.3-final/templates/chat-interface.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/templates/chat-interface.php
@@ -114,6 +114,11 @@ if (!defined('ABSPATH')) {
                 esc_url($src)
             );
             ?>
+            <script
+              src="https://cdn.typebot.co/widget.js"
+              id="typebot-widget"
+              async
+            ></script>
             <div id="mhtp-session-overlay" class="mhtp-session-overlay" style="display:none;">
                 Tu sesión ha concluido
             </div>
@@ -123,7 +128,6 @@ if (!defined('ABSPATH')) {
                     <div id="mhtp-session-timer" class="mhtp-session-timer">45:00</div>
                 </div>
             </div>
-            <script src="https://cdn.typebot.io/widget.js" defer></script>
             <script>
             document.addEventListener('typebot-widget-ready', () => {
               const btn = document.getElementById('mhtp-end-session');


### PR DESCRIPTION
## Summary
- load Typebot widget via CDN and use it as a dependency
- wait for `window.TypebotWidget` before initializing
- bump plugin version to 3.1.8
- note new behaviour in README

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b21e0f3b48325a5277dbaadfdf1be