### PR TITLE
Fix Typebot widget load sequence

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/README.md
+++ b/mhtp-chat-woocommerce-v1.3.3-final/README.md
@@ -1,4 +1,4 @@
-# MHTP Chat Interface - Version 3.1.9
+# MHTP Chat Interface - Version 3.1.10
 
 **Note:** This plugin was originally built for Botpress. It now includes
 built-in support for embedding a [Typebot](https://typebot.io) conversation

--- a/mhtp-chat-woocommerce-v1.3.3-final/assets/js/mhtp-chat-init.js
+++ b/mhtp-chat-woocommerce-v1.3.3-final/assets/js/mhtp-chat-init.js
@@ -38,7 +38,7 @@
     /**
      * Initialise the Typebot widget and attach the end chat handler.
      */
-    function init() {
+    function initChat() {
         var expertId = getExpertId();
         var userId = getUserId();
 
@@ -64,44 +64,25 @@
 
     }
 
-    function waitForTypebotWidget() {
-        return new Promise(function (resolve) {
-            if (window.TypebotWidget) {
-                resolve();
-                return;
-            }
-            var timer = setInterval(function () {
-                if (window.TypebotWidget) {
-                    clearInterval(timer);
-                    resolve();
-                }
-            }, 50);
-        });
-    }
-
-    function start() {
-        waitForTypebotWidget().then(function () {
+    const waitForWidget = () => {
+        if (window.TypebotWidget) {
             window.TypebotWidget.ready(function () {
-                init();
-
-                var endBtn = document.getElementById('mhtp-end-session');
-                if (endBtn) {
-                    endBtn.addEventListener('click', async function () {
-                        console.log('¡click finalizar! enviando store-conversation');
+                initChat();
+                var btn = document.getElementById('mhtp-end-session');
+                if (btn) {
+                    btn.addEventListener('click', async function () {
                         try {
-                            await TypebotWidget.sendCommand({ command: 'store-conversation' });
+                            await window.TypebotWidget.sendCommand({ command: 'store-conversation' });
                         } catch (e) {
-                            console.error('Typebot sendCommand falló:', e);
+                            console.error('Typebot command failed:', e);
                         }
                     });
                 }
             });
-        });
-    }
+        } else {
+            setTimeout(waitForWidget, 50);
+        }
+    };
 
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', start);
-    } else {
-        start();
-    }
+    waitForWidget();
 })();

--- a/mhtp-chat-woocommerce-v1.3.3-final/includes/class-mhtp-chat.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/includes/class-mhtp-chat.php
@@ -5,7 +5,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class MHTP_Chat {
     /** Plugin version */
-    const VERSION = '3.1.9';
+    const VERSION = '3.1.10';
     public function __construct() {
         add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
     }
@@ -17,7 +17,7 @@ class MHTP_Chat {
 
         wp_enqueue_script(
             'mhtp-typebot-widget',
-            'https://cdn.typebot.io/widget.js',
+            'https://cdn.typebot.co/widget.js',
             array(),
             null,
             true

--- a/mhtp-chat-woocommerce-v1.3.3-final/templates/chat-interface.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/templates/chat-interface.php
@@ -88,7 +88,7 @@ if (!defined('ABSPATH')) {
         <div class="mhtp-chat-main">
             <?php
             $cfg      = get_option('mhtp_typebot_options');
-            $url      = !empty($cfg['chatbot_url']) ? $cfg['chatbot_url'] : 'https://typebot.io/especialista-5gzhab4';
+            $url      = !empty($cfg['chatbot_url']) ? $cfg['chatbot_url'] : 'https://typebot.co/especialista-5gzhab4';
             // Always use the .co domain for the embed
             $url      = str_replace('typebot.io', 'typebot.co', $url);
             $selected = isset($cfg['selected_params']) && is_array($cfg['selected_params']) ? $cfg['selected_params'] : array();
@@ -116,7 +116,6 @@ if (!defined('ABSPATH')) {
                 esc_url($src)
             );
             ?>
-            <script src="https://cdn.typebot.co/widget.js?rum=false" id="mhtp-typebot-widget-js" defer></script>
             <div id="mhtp-session-overlay" class="mhtp-session-overlay" style="display:none;">
                 Tu sesión ha concluido
             </div>
@@ -126,31 +125,6 @@ if (!defined('ABSPATH')) {
                     <div id="mhtp-session-timer" class="mhtp-session-timer">45:00</div>
                 </div>
             </div>
-            <script>
-            (function () {
-                function ready(cb) {
-                    if (window.TypebotWidget && typeof window.TypebotWidget.sendCommand === 'function') {
-                        cb();
-                    } else {
-                        window.addEventListener('typebot-widget-ready', cb, { once: true });
-                    }
-                }
-
-                ready(function () {
-                    var btn = document.getElementById('mhtp-end-session');
-                    if (!btn) { return; }
-                    btn.addEventListener('click', async function () {
-                        console.log('📤 store-conversation trigger');
-                        try {
-                            await window.TypebotWidget.sendCommand({ command: 'store-conversation' });
-                            console.log('✅ store-conversation success');
-                        } catch (err) {
-                            console.error('❌ store-conversation error', err);
-                        }
-                    });
-                });
-            })();
-            </script>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- load Typebot widget from `cdn.typebot.co` via `wp_enqueue_script`
- bump plugin version to 3.1.10
- ensure `.co` domain in embed iframe
- clean up template JavaScript
- wait for widget runtime in init script and hook end-session to store conversation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ba3a45d4c8325a36a14584f784ac6