### PR TITLE
Fix Typebot widget loading

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/README.md
+++ b/mhtp-chat-woocommerce-v1.3.3-final/README.md
@@ -1,4 +1,4 @@
-# MHTP Chat Interface - Version 3.1.10
+# MHTP Chat Interface - Version 3.1.11
 
 **Note:** This plugin was originally built for Botpress. It now includes
 built-in support for embedding a [Typebot](https://typebot.io) conversation
@@ -73,6 +73,11 @@ This plugin now properly handles session decrementation when users start a chat:
 3. If no sessions of either type are available, the user receives an error message
 
 ## Changelog
+
+### 3.1.11
+- Fixed widget domain: now loading from `cdn.typebot.io`
+- Enqueued widget script before chat init
+- Added polling for `window.TypebotWidget` to prevent race conditions
 
 ### 3.1.9
 * Store-conversation command now triggered by the widget-ready listener.

--- a/mhtp-chat-woocommerce-v1.3.3-final/assets/js/mhtp-chat-init.js
+++ b/mhtp-chat-woocommerce-v1.3.3-final/assets/js/mhtp-chat-init.js
@@ -36,7 +36,7 @@
     }
 
     /**
-     * Initialise the Typebot widget and attach the end chat handler.
+     * Initialise the Typebot widget.
      */
     function initChat() {
         var expertId = getExpertId();
@@ -64,25 +64,29 @@
 
     }
 
-    const waitForWidget = () => {
-        if (window.TypebotWidget) {
-            window.TypebotWidget.ready(function () {
-                initChat();
-                var btn = document.getElementById('mhtp-end-session');
-                if (btn) {
-                    btn.addEventListener('click', async function () {
-                        try {
-                            await window.TypebotWidget.sendCommand({ command: 'store-conversation' });
-                        } catch (e) {
-                            console.error('Typebot command failed:', e);
-                        }
-                    });
-                }
-            });
-        } else {
-            setTimeout(waitForWidget, 50);
-        }
-    };
+    function attachEndHandler() {
+        var btn = document.getElementById('mhtp-end-session');
+        if (!btn) return;
+        btn.addEventListener('click', async function () {
+            try {
+                await window.TypebotWidget.sendCommand({ command: 'store-conversation' });
+            } catch (e) {
+                console.error('Typebot command failed:', e);
+            }
+        });
+    }
 
-    waitForWidget();
+    function waitForWidget(cb) {
+        const t0 = Date.now();
+        (function poll() {
+            if (window.TypebotWidget) return cb();
+            if (Date.now() - t0 < 5000) return setTimeout(poll, 100);
+            console.error('TypebotWidget never loaded');
+        })();
+    }
+
+    waitForWidget(function () {
+        initChat();
+        attachEndHandler();
+    });
 })();

--- a/mhtp-chat-woocommerce-v1.3.3-final/includes/class-mhtp-chat.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/includes/class-mhtp-chat.php
@@ -5,7 +5,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class MHTP_Chat {
     /** Plugin version */
-    const VERSION = '3.1.10';
+    const VERSION = '3.1.11';
     public function __construct() {
         add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
     }
@@ -17,7 +17,7 @@ class MHTP_Chat {
 
         wp_enqueue_script(
             'mhtp-typebot-widget',
-            'https://cdn.typebot.co/widget.js',
+            'https://cdn.typebot.io/widget.js',
             array(),
             null,
             true

--- a/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
@@ -3,7 +3,7 @@
  * Plugin Name: MHTP Chat Interface
  * Plugin URI: https://mhtp.com
  * Description: Chat interface for Mental Health Triage Platform using Typebot
- * Version: 3.1.8
+ * Version: 3.1.11
  * Author: MHTP Team
  * Author URI: https://mhtp.com
  * Text Domain: mhtp-chat-interface
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('MHTP_CHAT_VERSION', '3.1.8');
+define('MHTP_CHAT_VERSION', '3.1.11');
 define('MHTP_CHAT_PLUGIN_DIR', plugin_dir_path(__FILE__));
 require_once MHTP_CHAT_PLUGIN_DIR . 'includes/class-mhtp-chat.php';
 define('MHTP_CHAT_PLUGIN_URL', plugin_dir_url(__FILE__));
@@ -29,11 +29,11 @@ if (!defined('MHTP_CHAT_ENABLE_LOG')) {
 // Botpress Chat API base URL (no trailing slash)
 define('MHTP_BOTPRESS_CHAT_API', 'https://chat.botpress.cloud/v1');
 
-// Force the Typebot embed to use the .co domain
+// Force the Typebot embed to use the .io domain
 add_filter(
     'mhtp_typebot_embed_base',
     static function () {
-        return 'https://typebot.co/';
+        return 'https://typebot.io/';
     }
 );
 

--- a/mhtp-chat-woocommerce-v1.3.3-final/templates/chat-interface.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/templates/chat-interface.php
@@ -88,9 +88,9 @@ if (!defined('ABSPATH')) {
         <div class="mhtp-chat-main">
             <?php
             $cfg      = get_option('mhtp_typebot_options');
-            $url      = !empty($cfg['chatbot_url']) ? $cfg['chatbot_url'] : 'https://typebot.co/especialista-5gzhab4';
-            // Always use the .co domain for the embed
-            $url      = str_replace('typebot.io', 'typebot.co', $url);
+            $url      = !empty($cfg['chatbot_url']) ? $cfg['chatbot_url'] : 'https://typebot.io/especialista-5gzhab4';
+            // Always use the .io domain for the embed
+            $url      = str_replace('typebot.co', 'typebot.io', $url);
             $selected = isset($cfg['selected_params']) && is_array($cfg['selected_params']) ? $cfg['selected_params'] : array();
 
             $current_user = wp_get_current_user();


### PR DESCRIPTION
## Summary
- load Typebot widget from cdn.typebot.io
- ensure widget loads before init script
- poll for `window.TypebotWidget` before starting chat
- update defaults to `.io` domain
- bump version to 3.1.11

## Testing
- `php -l` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc03d46bc8325ad8758cabd6e797b