### PR TITLE
Update chat plugin to 3.1.12

### DIFF
--- a/mhtp-chat-woocommerce-v1.3.3-final/README.md
+++ b/mhtp-chat-woocommerce-v1.3.3-final/README.md
@@ -1,4 +1,4 @@
-# MHTP Chat Interface - Version 3.1.11
+# MHTP Chat Interface - Version 3.1.12
 
 **Note:** This plugin was originally built for Botpress. It now includes
 built-in support for embedding a [Typebot](https://typebot.io) conversation
@@ -73,6 +73,9 @@ This plugin now properly handles session decrementation when users start a chat:
 3. If no sessions of either type are available, the user receives an error message
 
 ## Changelog
+
+### 3.1.12
+- Enqueue the Typebot widget via its own handle and add it as a dependency to the chat init script for correct load order.
 
 ### 3.1.11
 - Fixed widget domain: now loading from `cdn.typebot.io`

--- a/mhtp-chat-woocommerce-v1.3.3-final/includes/class-mhtp-chat.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/includes/class-mhtp-chat.php
@@ -5,7 +5,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class MHTP_Chat {
     /** Plugin version */
-    const VERSION = '3.1.11';
+    const VERSION = '3.1.12';
     public function __construct() {
         add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
     }
@@ -15,13 +15,15 @@ class MHTP_Chat {
         $user       = wp_get_current_user();
         $user_email = ( $user instanceof WP_User ) ? $user->user_email : '';
 
-        wp_enqueue_script(
+        wp_register_script(
             'mhtp-typebot-widget',
             'https://cdn.typebot.io/widget.js',
             array(),
-            null,
+            MHTP_CHAT_VERSION,
             true
         );
+
+        wp_enqueue_script( 'mhtp-typebot-widget' );
 
         wp_register_script(
             'mhtp-chat-init',

--- a/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
+++ b/mhtp-chat-woocommerce-v1.3.3-final/mhtp-chat-interface.php
@@ -3,7 +3,7 @@
  * Plugin Name: MHTP Chat Interface
  * Plugin URI: https://mhtp.com
  * Description: Chat interface for Mental Health Triage Platform using Typebot
- * Version: 3.1.11
+ * Version: 3.1.12
  * Author: MHTP Team
  * Author URI: https://mhtp.com
  * Text Domain: mhtp-chat-interface
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('MHTP_CHAT_VERSION', '3.1.11');
+define('MHTP_CHAT_VERSION', '3.1.12');
 define('MHTP_CHAT_PLUGIN_DIR', plugin_dir_path(__FILE__));
 require_once MHTP_CHAT_PLUGIN_DIR . 'includes/class-mhtp-chat.php';
 define('MHTP_CHAT_PLUGIN_URL', plugin_dir_url(__FILE__));


### PR DESCRIPTION
## Summary
- bump version constants to 3.1.12
- register Typebot widget script before enqueueing it
- keep chat init script dependent on widget
- document the change in README

## Testing
- `php -l mhtp-chat-woocommerce-v1.3.3-final/includes/class-mhtp-chat.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685bd08326008325b95332256743e53b